### PR TITLE
fix(command): close console output after server start to prevent bad …

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/ServerStartCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerStartCommand.php
@@ -59,9 +59,9 @@ final class ServerStartCommand extends ServerExecutionCommand
             throw CouldNotCreatePidFileException::forPath($pidFile);
         }
 
-        $this->closeSymfonyStyle($io);
-
         $server->start();
+
+        $this->closeSymfonyStyle($io);
     }
 
     private function closeSymfonyStyle(SymfonyStyle $io): void


### PR DESCRIPTION
…file descriptor in docker

If close sf console output occurs between server configuration and start(), swoole emit warning: 
`WARNING Logger::redirect_stdout_and_stderr(): dup(STDOUT_FILENO) failed, Error: Bad file descriptor[9]`