### PR TITLE
fix(access-log): set default timezone from php since $timezone parame…

### DIFF
--- a/src/Bridge/Log/SymfonyAccessLogDataMap.php
+++ b/src/Bridge/Log/SymfonyAccessLogDataMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SwooleBundle\SwooleBundle\Bridge\Log;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use IntlDateFormatter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -301,6 +302,7 @@ final class SymfonyAccessLogDataMap implements AccessLogDataMap
             default:
                 // Cast to int first, as it may be a float
                 $requestTime = new DateTimeImmutable('@' . (int) $time);
+                $requestTime = $requestTime->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
                 return IntlDateFormatter::formatObject(
                     $requestTime,

--- a/tests/Unit/Bridge/Log/AccessLogFormatterTest.php
+++ b/tests/Unit/Bridge/Log/AccessLogFormatterTest.php
@@ -31,9 +31,9 @@ final class AccessLogFormatterTest extends TestCase
             ->method('getRequestDuration')
             ->willReturnCallback(
                 static fn(string $format) => match ([$format]) { // @phpstan-ignore-line
-                    ['ms'] => '4321', // %D
-                    ['s'] => '22', // %T
-                    ['us'] => '22', // %{us}T
+                    ['ms'] => '4321', // %{ms}T
+                    ['s'] => '4', // %T
+                    ['us'] => '4321210', // %{us}T, %D
                 }
             );
         $dataMap->method('getFilename')->willReturn(__FILE__); // %f
@@ -84,7 +84,7 @@ final class AccessLogFormatterTest extends TestCase
             '127.0.0.1',
             '1234',
             '1234',
-            '4321',
+            '4321210',
             __FILE__,
             $hostname,
             'HTTP/1.1',
@@ -94,7 +94,7 @@ final class AccessLogFormatterTest extends TestCase
             'POST /path?foo=bar HTTP/1.1',
             '202',
             '[1234567890]',
-            '22',
+            '4',
             'swoole',
             '/path',
             'swoole.local',
@@ -108,7 +108,7 @@ final class AccessLogFormatterTest extends TestCase
             'response',
             '9999',
             '[1234567890]',
-            '22',
+            '4321210',
         ];
         $expected = implode(' ', $expected);
 

--- a/tests/Unit/Bridge/Log/SymfonyAccessLogDataMapTest.php
+++ b/tests/Unit/Bridge/Log/SymfonyAccessLogDataMapTest.php
@@ -98,4 +98,18 @@ final class SymfonyAccessLogDataMapTest extends TestCase
 
         $this->assertSame('[02/Dec/2021:02:21:12 ' . $date->format('O') . ']', $requestTime);
     }
+
+    public function testGetHttpFoundationRequestTimeInDifferentTimeZoneAsUTC(): void
+    {
+        $oldTZ = date_default_timezone_get();
+        date_default_timezone_set('Europe/Bratislava');
+        $tz = new DateTimeZone(date_default_timezone_get());
+        $date = new DateTimeImmutable('2021-12-02T02:21:12.4242', $tz);
+        $this->request->server = new ServerBag(['REQUEST_TIME_FLOAT' => (float) $date->getTimestamp()]);
+        $map = new SymfonyAccessLogDataMap($this->request, $this->response, false);
+        $requestTime = $map->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z');
+
+        $this->assertSame('[02/Dec/2021:02:21:12 ' . $date->format('O') . ']', $requestTime);
+        date_default_timezone_set($oldTZ);
+    }
 }


### PR DESCRIPTION
…ter and the current timezone are ignored when the $datetime parameter is a UNIX timestamp (starts with @)

another fix :) @Rastusik thx for release