### PR TITLE
Minor refactor: simplify "fromTreeBuilder"

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -439,8 +439,6 @@ final class Configuration implements ConfigurationInterface
 
     public static function fromTreeBuilder(): self
     {
-        $treeBuilderClass = TreeBuilder::class;
-
-        return new self(new $treeBuilderClass(self::CONFIG_NAME));
+        return new self(new TreeBuilder(self::CONFIG_NAME));
     }
 }


### PR DESCRIPTION
There's no need to have separate variable. Probably it was used for BC with Symfony 4.4 before