### PR TITLE
Fix overwriting trusted hosts / proxies

### DIFF
--- a/src/Bridge/Symfony/Bundle/Command/ServerExecutionCommand.php
+++ b/src/Bridge/Symfony/Bundle/Command/ServerExecutionCommand.php
@@ -234,10 +234,18 @@ abstract class ServerExecutionCommand extends Command
         Assertion::isArray($trustedProxies);
         Assertion::allString($trustedProxies);
         $runtimeConfiguration = [];
-        $runtimeConfiguration['trustedHosts'] = $this->decodeSet($trustedHosts);
-        $runtimeConfiguration['trustedProxies'] = $this->decodeSet($trustedProxies);
 
-        if (in_array('*', $runtimeConfiguration['trustedProxies'], true)) {
+        if ($trustedHosts !== []) {
+            $runtimeConfiguration['trustedHosts'] = $this->decodeSet($trustedHosts);
+        }
+        if ($trustedProxies !== []) {
+            $runtimeConfiguration['trustedProxies'] = $this->decodeSet($trustedProxies);
+        }
+
+        if (
+            array_key_exists('trustedProxies', $runtimeConfiguration)
+            && in_array('*', $runtimeConfiguration['trustedProxies'], true)
+        ) {
             $runtimeConfiguration['trustAllProxies'] = true;
             $runtimeConfiguration['trustedProxies'] = array_filter(
                 $runtimeConfiguration['trustedProxies'],


### PR DESCRIPTION
Symfony loads its values first when booted, then it starts registering bundles and this bundle overwrites config from
```
framework:
    trusted_proxies:
```
The code in this bundle in `SetRequestRuntimeConfiguration` works when this value is not being set in config. 

I tried writing tests but I need to somehow hook into container to get request so I can call::getTrustedProxies() on that, but I didn't find a way to do that. I've tested it in real application and it works there 