### PR TITLE
coroutine test - notes

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
@@ -29,6 +29,7 @@ final class StatefulServicesPass implements CompilerPassInterface
 {
     private const IGNORED_SERVICES = [
         BlockingContainer::class => true,
+        'http_client.transport' => true,//Symfony\Contracts\HttpClient\HttpClientInterface
     ];
 
     private const MANDATORRY_SERVICES_TO_PROXIFY = [

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.php
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.php
@@ -424,6 +424,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('setGeneratorStrategy', [
             service('swoole_bundle.repository_proxy_file_writer_generator'),
         ])
+        ->call('setProxiesNamespace', [
+            'PN',
+        ])
         ->call('setProxiesTargetDir', [
             '%swoole_bundle.service_proxy_cache_dir%',
         ]);

--- a/src/Bridge/Symfony/Container/Modifier/Builder/Symfony63PlusBuilder.php
+++ b/src/Bridge/Symfony/Container/Modifier/Builder/Symfony63PlusBuilder.php
@@ -159,7 +159,7 @@ final class Symfony63PlusBuilder implements Builder
     private static function generateOverrideOriginalContainerLoad(): string
     {
         return <<<'EOF'
-                protected function load(string $file)
+                protected function load(string $file): mixed
                 {
                     self::$mutex->acquire();
 


### PR DESCRIPTION
Hi @Rastusik 
I tested coroutines in sf app, an here are some notes

- z-egnine exception in sentry/sentry lib, will add more details later

```In ReflectionValue.php line 243:
                                                                 
  Class entry available only for the type IS_PTR or IS_INDIRECT 
```

- In Profiler, execution time is still increasing since server start

<img width="320" height="157" alt="image" src="https://github.com/user-attachments/assets/5138cf37-57ce-4378-8220-53ccba858808" />


more in comments