### PR TITLE
fix(proxifier): add interface_exists in StatafulServicePass

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
@@ -172,11 +172,16 @@ final class StatefulServicesPass implements CompilerPassInterface
             if ($resetter !== null && str_starts_with($resetter, '?')) {
                 $definition = $container->findDefinition($serviceId);
                 $definitionClass = $definition->getClass();
-                Assertion::classExists($definitionClass);
-                $resetter = substr($resetter, 1);
 
-                if (!method_exists($definitionClass, $resetter)) {
+                if ($definitionClass !== null && interface_exists($definitionClass)) {
                     $resetter = null;
+                } else {
+                    Assertion::classExists($definitionClass);
+                    $resetter = substr($resetter, 1);
+
+                    if (!method_exists($definitionClass, $resetter)) {
+                        $resetter = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes crash when optional resetters are defined for services that use interface aliases (e.g. HttpClientInterface, AdapterInterface).

The ProxifierAssertions trait already handles interfaces correctly by checking interface_exists() before calling classExists(), but StatefulServicesPass was calling Assertion::classExists() directly without this check.

This change makes StatefulServicesPass consistent with ProxifierAssertions by skipping optional resetters for interface-based services since interfaces don't have methods to call.

Fixes error: Class "Symfony\Contracts\HttpClient\HttpClientInterface" does not exist

Duplicate of #218 by @kkrasnik
Resolves #218 