### PR TITLE
fix(coroutines): fixed service resetting and removed as much concurrent data accesses as possible

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -132,6 +132,7 @@
   <file>src</file>
   <file>tests</file>
   <exclude-pattern>/src/Bridge/Monolog/StreamHandler\.php$</exclude-pattern>
+  <exclude-pattern>/tests/Fixtures/Symfony/app/config/reference.php</exclude-pattern>
   <exclude-pattern>/tests/Fixtures/Symfony/app/var/*</exclude-pattern>
 
 </ruleset>

--- a/src/Bridge/Doctrine/DoctrineProcessor.php
+++ b/src/Bridge/Doctrine/DoctrineProcessor.php
@@ -124,6 +124,9 @@ final class DoctrineProcessor implements CompileProcessor
             }
 
             $connectionDef->addTag(ContainerConstants::TAG_STATEFUL_SERVICE, $tagParams);
+            $connectionEventManagerSvcId = sprintf('doctrine.dbal.%s_connection.event_manager', $connectionName);
+            $connectionEventManagerDef = $container->findDefinition($connectionEventManagerSvcId);
+            $connectionEventManagerDef->addTag(ContainerConstants::TAG_STATEFUL_SERVICE, ['limit' => $limit]);
         }
     }
 

--- a/src/Bridge/Monolog/StreamHandler.php
+++ b/src/Bridge/Monolog/StreamHandler.php
@@ -34,7 +34,6 @@ final class StreamHandler extends AbstractProcessingHandler
      */
     protected $stream;
     protected string|null $url = null;
-    private string|null $errorMessage = null;
 
     /**
      * @var true|null
@@ -121,11 +120,17 @@ final class StreamHandler extends AbstractProcessingHandler
         $this->mutex = $mutex;
     }
 
-    public function customErrorHandler(int $code, string $msg): bool
+    /**
+     * this callback will ensure that in each coroutine only the correct stream handler instance will get
+     * the error message.
+     */
+    public function customErrorHandler(?string &$errorMessage): callable
     {
-        $this->errorMessage = preg_replace('{^(fopen|mkdir)\(.*?\): }', '', $msg);
+        return function (int $code, string $msg) use (&$errorMessage): bool {
+            $errorMessage = preg_replace('{^(fopen|mkdir)\(.*?\): }', '', $msg);
 
-        return true;
+            return true;
+        };
     }
 
     protected function write(LogRecord $record): void
@@ -140,17 +145,17 @@ final class StreamHandler extends AbstractProcessingHandler
                 );
             }
             $this->createDir($url);
-            $this->errorMessage = null;
+            $errorMessage = null;
 
             try {
                 $this->mutex->acquire();
-                set_error_handler($this->customErrorHandler(...));
+                set_error_handler($this->customErrorHandler($errorMessage));
                 $stream = fopen($url, 'a');
                 if ($this->filePermission !== null) {
                     @chmod($url, $this->filePermission);
                 }
-                restore_error_handler();
             } finally {
+                restore_error_handler();
                 $this->mutex->release();
             }
 
@@ -159,7 +164,7 @@ final class StreamHandler extends AbstractProcessingHandler
 
                 throw new UnexpectedValueException(
                     sprintf(
-                        'The stream or file "%s" could not be opened in append mode: ' . $this->errorMessage,
+                        'The stream or file "%s" could not be opened in append mode: ' . $errorMessage,
                         $url
                     ) . Utils::getRecordMessageForException(
                         $record
@@ -226,21 +231,21 @@ final class StreamHandler extends AbstractProcessingHandler
 
         $dir = $this->getDirFromStream($url);
         if ($dir !== null && !is_dir($dir)) {
-            $this->errorMessage = null;
+            $errorMessage = null;
 
             try {
                 $this->mutex->acquire();
-                set_error_handler($this->customErrorHandler(...));
+                set_error_handler($this->customErrorHandler($errorMessage));
                 $status = mkdir($dir, 0o777, true);
-                restore_error_handler();
             } finally {
+                restore_error_handler();
                 $this->mutex->release();
             }
 
-            if ($status === false && !is_dir($dir) && !str_contains((string) $this->errorMessage, 'File exists')) {
+            if ($status === false && !is_dir($dir) && !str_contains((string) $errorMessage, 'File exists')) {
                 throw new UnexpectedValueException(
                     sprintf(
-                        'There is no existing directory at "%s" and it could not be created: ' . $this->errorMessage,
+                        'There is no existing directory at "%s" and it could not be created: ' . $errorMessage,
                         $dir
                     )
                 );

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServices/NonSharedSvcPoolConfigurator.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServices/NonSharedSvcPoolConfigurator.php
@@ -6,6 +6,7 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\Co
 
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\BaseServicePool;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\ServicePoolContainer;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\ServicePoolEntry;
 
 final readonly class NonSharedSvcPoolConfigurator
 {
@@ -16,6 +17,6 @@ final readonly class NonSharedSvcPoolConfigurator
      */
     public function configure(BaseServicePool $servicePool): void
     {
-        $this->container->addPool($servicePool);
+        $this->container->addPoolEntry(new ServicePoolEntry($servicePool));
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServices/Proxifier.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServices/Proxifier.php
@@ -11,6 +11,7 @@ use SwooleBundle\SwooleBundle\Bridge\Doctrine\ORM\EntityManagerStabilityChecker;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\ContainerConstants;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Proxy\Instantiator;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\DiServicePool;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\ServicePoolEntry;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\SimpleResetter;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\StabilityChecker;
 use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
@@ -30,9 +31,9 @@ final class Proxifier
     ];
 
     /**
-     * @var array<int, array<Reference>>
+     * @var array<int, Definition>
      */
-    private array $proxifiedServicePoolRefs = [];
+    private array $proxifiedServicePoolEntryDefs = [];
 
     /**
      * @var array<class-string, class-string<StabilityChecker>|string>
@@ -76,13 +77,13 @@ final class Proxifier
     }
 
     /**
-     * @return array<int, array<Reference>>
+     * @return array<int, Definition>
      */
-    public function getProxifiedServicePoolRefs(): array
+    public function getProxifiedServicePoolEntryDefs(): array
     {
-        krsort($this->proxifiedServicePoolRefs);
+        krsort($this->proxifiedServicePoolEntryDefs);
 
-        return $this->proxifiedServicePoolRefs;
+        return $this->proxifiedServicePoolEntryDefs;
     }
 
     private function doProxifyService(
@@ -95,8 +96,12 @@ final class Proxifier
             throw new RuntimeException(sprintf('Service missing: %s', $serviceId));
         }
 
+        /** @var class-string $serviceClass */
+        $serviceClass = $serviceDef->getClass();
+        $serviceTags = new Tags($serviceClass, $serviceDef->getTags());
+
         $wrappedServiceId = sprintf('%s.swoole_coop.wrapped', $serviceId);
-        $svcPoolDef = $this->prepareServicePool($wrappedServiceId, $serviceDef, $externalResetter);
+        $svcPoolDef = $this->prepareServicePool($wrappedServiceId, $serviceDef, $serviceTags);
         $svcPoolServiceId = sprintf('%s.swoole_coop.service_pool', $serviceId);
         $wasShared = $serviceDef->isShared();
         $proxyDef = $this->prepareProxy($svcPoolServiceId, $serviceDef);
@@ -112,7 +117,30 @@ final class Proxifier
             return;
         }
 
-        $this->registerProxifiedServicePoolRef(new Reference($svcPoolServiceId), $resetPriority);
+        $customResetter = null;
+        $serviceTag = $serviceTags->findStatefulServiceTag();
+
+        if ($serviceTag?->getResetter() !== null) {
+            $customResetter = $serviceTag->getResetter();
+        }
+
+        $resetterDefOrRef = null;
+
+        if ($customResetter !== null) {
+            $resetterDefOrRef = new Reference($customResetter);
+        }
+
+        if ($resetterDefOrRef === null && $externalResetter !== null) {
+            $resetterDefOrRef = new Definition();
+            $resetterDefOrRef->setClass(SimpleResetter::class);
+            $resetterDefOrRef->setArgument(0, $externalResetter);
+        }
+
+        $this->registerProxifiedServicePoolEntryDefinition(
+            new Reference($svcPoolServiceId),
+            $resetterDefOrRef,
+            $resetPriority,
+        );
     }
 
     private function doProxifyDecoratedService(
@@ -150,11 +178,8 @@ final class Proxifier
         $serviceDef->setShared(false);
     }
 
-    private function prepareServicePool(
-        string $wrappedServiceId,
-        Definition $serviceDef,
-        ?string $externalResetter = null,
-    ): Definition {
+    private function prepareServicePool(string $wrappedServiceId, Definition $serviceDef, Tags $serviceTags): Definition
+    {
         $svcPoolDef = new Definition(DiServicePool::class);
         $svcPoolDef->setShared($serviceDef->isShared());
 
@@ -174,38 +199,14 @@ final class Proxifier
             );
         }
 
-        /** @var class-string $serviceClass */
-        $serviceClass = $serviceDef->getClass();
-        $serviceTags = new Tags($serviceClass, $serviceDef->getTags());
         $serviceTag = $serviceTags->findStatefulServiceTag();
-        $customResetter = null;
+        $serviceClass = $serviceDef->getClass();
 
         if ($serviceTag?->getLimit() !== null) {
             $instanceLimit = $serviceTag->getLimit();
         }
 
-        if ($serviceTag?->getResetter() !== null) {
-            $customResetter = $serviceTag->getResetter();
-        }
-
         $svcPoolDef->setArgument(4, $instanceLimit);
-        $svcPoolDef->setArgument(5, null);
-
-        $resetterDefOrRef = null;
-
-        if ($customResetter !== null) {
-            $resetterDefOrRef = new Reference($customResetter);
-        }
-
-        if ($resetterDefOrRef === null && $externalResetter !== null) {
-            $resetterDefOrRef = new Definition();
-            $resetterDefOrRef->setClass(SimpleResetter::class);
-            $resetterDefOrRef->setArgument(0, $externalResetter);
-        }
-
-        if ($resetterDefOrRef) {
-            $svcPoolDef->setArgument(5, $resetterDefOrRef);
-        }
 
         $stabilityCheckerRef = null;
 
@@ -215,10 +216,10 @@ final class Proxifier
             $stabilityCheckerRef = new Reference($checkerSvcId);
         }
 
-        $svcPoolDef->setArgument(6, $stabilityCheckerRef);
+        $svcPoolDef->setArgument(5, $stabilityCheckerRef);
 
         if ($serviceTag?->getInitializer() !== null) {
-            $svcPoolDef->setArgument(7, new Reference($serviceTag->getInitializer()));
+            $svcPoolDef->setArgument(6, new Reference($serviceTag->getInitializer()));
         }
 
         return $svcPoolDef;
@@ -283,12 +284,19 @@ final class Proxifier
         return !$factorySvc instanceof Reference || (string) $factorySvc !== Instantiator::class;
     }
 
-    private function registerProxifiedServicePoolRef(Reference $ref, int $resetPriority): void
-    {
-        if (!isset($this->proxifiedServicePoolRefs[$resetPriority])) {
-            $this->proxifiedServicePoolRefs[$resetPriority] = [];
+    private function registerProxifiedServicePoolEntryDefinition(
+        Reference $ref,
+        Definition|Reference|null $resetterDefOrRef = null,
+        int $resetPriority = 0,
+    ): void {
+        $recordDef = new Definition(ServicePoolEntry::class);
+        $recordDef->setArgument(0, $ref);
+
+        if ($resetterDefOrRef !== null) {
+            $recordDef->setArgument(1, $resetterDefOrRef);
+            $recordDef->setArgument(2, $resetPriority);
         }
 
-        $this->proxifiedServicePoolRefs[$resetPriority][] = $ref;
+        $this->proxifiedServicePoolEntryDefs[] = $recordDef;
     }
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
@@ -35,15 +35,20 @@ final class StatefulServicesPass implements CompilerPassInterface
 
     private const array MANDATORRY_SERVICES_TO_PROXIFY = [
         'kernel_proxy',
+        'http_kernel',
         'annotations.reader',
         'logger',
         'profiler_listener',
         'debug.event_dispatcher',
+        'debug.debug_handlers_listener',
         'debug.stopwatch',
         'request_stack',
         'router.request_context',
         'router',
         'router.default',
+        'request_stack',
+        'slugger',
+        'swoole_bundle.error_handler.symfony_error_handler',
     ];
 
     private const array SERVICE_RESETTING_PRIORITIES = [
@@ -293,9 +298,9 @@ final class StatefulServicesPass implements CompilerPassInterface
 
     private function configureServicePoolContainer(ContainerBuilder $container, Proxifier $proxifier): void
     {
-        $poolRefs = $proxifier->getProxifiedServicePoolRefs();
+        $poolEntryDefs = $proxifier->getProxifiedServicePoolEntryDefs();
         $poolContainerDef = $container->findDefinition(ServicePoolContainer::class);
-        $poolContainerDef->setArgument(0, $poolRefs);
+        $poolContainerDef->setArgument(0, $poolEntryDefs);
     }
 
     private function detectKernelClass(ContainerBuilder $container): void

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
@@ -12,6 +12,7 @@ use ReflectionMethod;
 use RuntimeException;
 use SwooleBundle\SwooleBundle\Bridge\Log\AccessLogFormatter;
 use SwooleBundle\SwooleBundle\Bridge\Log\SimpleAccessLogFormatter;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\EventDispatcher\DebugClassLoaderOverridingWorkerStartHandler;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\StabilityChecker;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\ErrorHandler\ErrorResponder;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\ErrorHandler\ExceptionHandlerFactory;
@@ -398,6 +399,15 @@ final class SwooleExtension extends Extension
                 new Reference(ContextReleasingHttpKernelRequestHandler::class . '.inner')
             );
             $coroutineKernelHandler->setDecoratedService(RequestHandler::class, null, -1000);
+
+            if ($this->isDebug($container) && PHP_OS_FAMILY === 'Darwin') {
+                $container->register(DebugClassLoaderOverridingWorkerStartHandler::class)
+                    ->setDecoratedService(WorkerStartHandler::class, null, -100)
+                    ->setArgument(
+                        '$decorated',
+                        new Reference(DebugClassLoaderOverridingWorkerStartHandler::class . '.inner'),
+                    );
+            }
         }
 
         if ($hmr['enabled'] === 'auto') {
@@ -488,13 +498,7 @@ final class SwooleExtension extends Extension
                 ->setDecoratedService(RequestHandler::class, null, -10);
         }
 
-        if (
-            $config['blackfire_profiler']
-            || (
-                $config['blackfire_profiler'] === false
-                && class_exists(BlackfireProfiler::class)
-            )
-        ) {
+        if ($config['blackfire_profiler'] && class_exists(BlackfireProfiler::class)) {
             $container->register(BlackfireProfiler::class)
                 ->setClass(BlackfireProfiler::class);
 
@@ -617,7 +621,7 @@ final class SwooleExtension extends Extension
         }
 
         $container->register('swoole_bundle.error_handler.symfony_error_handler', ErrorHandler::class)
-            ->setPublic(false);
+            ->setPublic(true);
         $container->register(ThrowableHandlerFactory::class)
             ->setPublic(false);
         $container->register('swoole_bundle.error_handler.symfony_kernel_throwable_handler', ReflectionMethod::class)

--- a/src/Bridge/Symfony/Bundle/EventDispatcher/DebugClassLoaderOverridingWorkerStartHandler.php
+++ b/src/Bridge/Symfony/Bundle/EventDispatcher/DebugClassLoaderOverridingWorkerStartHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\EventDispatcher;
+
+use ReflectionProperty;
+use Swoole\Server;
+use SwooleBundle\SwooleBundle\Server\WorkerHandler\WorkerStartHandler;
+use Symfony\Component\ErrorHandler\DebugClassLoader;
+
+/**
+ * Disables the Symfony DebugClassLoader's case-sensitivity checking on macOS (Darwin).
+ *
+ * On macOS with coroutines enabled, the DebugClassLoader's darwin realpath logic
+ * (which uses chdir/getcwd/scandir to normalize case-insensitive filesystem paths)
+ * causes race conditions when multiple coroutines try to autoload classes concurrently.
+ * The chdir/getcwd operations are process-global and not coroutine-safe, and scandir
+ * is a hookable IO operation that yields the coroutine, creating windows where other
+ * coroutines can step on the process working directory.
+ *
+ * This handler runs at onWorkerStart (the earliest safe point in a worker process)
+ * and disables the case check (caseCheck = 2 → 0) via reflection. This prevents
+ * DebugClassLoader::checkCase() from calling the problematic darwinRealpath method.
+ *
+ * The patch must happen in onWorkerStart, not in the parent process boot phase,
+ * because most class loading happens during initializeContainer() before SwooleBundle::boot(),
+ * and those early loads would still use caseCheck=2. By patching in onWorkerStart,
+ * we ensure the flag is correct for all coroutine-based class loading.
+ */
+final readonly class DebugClassLoaderOverridingWorkerStartHandler implements WorkerStartHandler
+{
+    public function __construct(
+        private WorkerStartHandler $decorated,
+    ) {}
+
+    public function handle(Server $server, int $workerId): void
+    {
+        $caseCheck = new ReflectionProperty(DebugClassLoader::class, 'caseCheck');
+        $caseCheckValue = $caseCheck->getValue();
+
+        if ($caseCheckValue === 2) { // disable case check on OSX with coroutines
+            $caseCheck->setValue(null, 0);
+        }
+
+        $this->decorated->handle($server, $workerId);
+    }
+}

--- a/src/Bridge/Symfony/Bundle/Resources/config/services.php
+++ b/src/Bridge/Symfony/Bundle/Resources/config/services.php
@@ -439,12 +439,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->arg('$proxiesDirectory', '%swoole_bundle.service_proxy_cache_dir%');
 
     $services->set(CoWrapper::class)
-        ->arg('$servicePoolContainer', service(ServicePoolContainer::class))
-        ->arg('$swoole', service(Swoole::class));
+        ->arg('$servicePoolContainer', service(ServicePoolContainer::class));
 
     $services->set(ServicePoolContainer::class)
-        ->arg('$pools', [
-        ]);
+        ->arg('$poolEntries', []);
 
     $services->set(EntityManagerStabilityChecker::class)
         ->tag('swoole_bundle.stability_checker');
@@ -488,7 +486,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->factory([
             service(SystemSwooleFactory::class),
             'newInstance',
-        ]);
+        ])
+        ->public();
 
     $services->set(HttpServerFactory::class)
         ->arg('$swoole', service(Swoole::class));

--- a/src/Bridge/Symfony/Bundle/SwooleBundle.php
+++ b/src/Bridge/Symfony/Bundle/SwooleBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle;
 
+use Assert\Assertion;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass\{
     BlackfireMonitoringPass,
     ExceptionHandlerPass,
@@ -13,9 +14,12 @@ use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\Compiler
     StatefulServicesPass,
     StreamedResponseListenerPass,
 };
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\ContainerConstants;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Debug\ErrorHandlerConfigurator;
 
 final class SwooleBundle extends Bundle
 {
@@ -28,5 +32,38 @@ final class SwooleBundle extends Bundle
         $container->addCompilerPass(new ExceptionHandlerPass());
         $container->addCompilerPass(new StatefulServicesPass(), PassConfig::TYPE_BEFORE_REMOVING, -10000);
         $container->addCompilerPass(new FinalizeDefinitionsAfterRemovalPass(), PassConfig::TYPE_AFTER_REMOVING, -10000);
+    }
+
+    /**
+     * in coroutine mode, we need to override the default error handler to not get an exception
+     * during normal runtime
+     */
+    public function boot(): void
+    {
+        Assertion::notNull($this->container);
+
+        if (!$this->container->hasParameter(ContainerConstants::PARAM_COROUTINES_ENABLED)) {
+            return;
+        }
+
+        if (!$this->container->getParameter(ContainerConstants::PARAM_COROUTINES_ENABLED)) {
+            return;
+        }
+
+        /** @var ErrorHandler $handler */
+        $handler = $this->container->get('swoole_bundle.error_handler.symfony_error_handler');
+        $debug = $this->container->getParameter('kernel.debug');
+
+        if ($debug) {
+            // override the default error handler registered earlier by Symfony to not get an exception
+            set_exception_handler([$handler, 'handleException']);
+        }
+
+        $handler = ErrorHandler::register($handler, true);
+        $configurator = $this->container->get('debug.error_handler_configurator');
+
+        Assertion::isInstanceOf($configurator, ErrorHandlerConfigurator::class);
+
+        $configurator->configure($handler);
     }
 }

--- a/src/Bridge/Symfony/Container/CoWrapper.php
+++ b/src/Bridge/Symfony/Container/CoWrapper.php
@@ -6,7 +6,6 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container;
 
 use Co;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\ServicePoolContainer;
-use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
 
 final class CoWrapper
 {
@@ -14,7 +13,6 @@ final class CoWrapper
 
     public function __construct(
         private readonly ServicePoolContainer $servicePoolContainer,
-        private readonly Swoole $swoole,
     ) {
         self::$instance = $this;
     }
@@ -22,7 +20,7 @@ final class CoWrapper
     public function defer(): void
     {
         Co::defer(function (): void {
-            $this->servicePoolContainer->releaseFromCoroutine($this->swoole->getCoroutineId());
+            $this->servicePoolContainer->releaseFromCoroutine();
         });
     }
 

--- a/src/Bridge/Symfony/Container/Proxy/Generation/MethodGenerator/MagicGet.php
+++ b/src/Bridge/Symfony/Container/Proxy/Generation/MethodGenerator/MagicGet.php
@@ -9,8 +9,8 @@ use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
 use ProxyManager\Generator\MagicMethodGenerator;
 use ProxyManager\ProxyGenerator\PropertyGenerator\PublicPropertiesMap;
-use ProxyManager\ProxyGenerator\Util\PublicScopeSimulator;
 use ReflectionClass;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Proxy\Generation\MethodGenerator\Util\PublicScopeSimulator;
 
 /**
  * Magic `__get` for lazy loading value holder objects.

--- a/src/Bridge/Symfony/Container/Proxy/Generation/MethodGenerator/Util/PublicScopeSimulator.php
+++ b/src/Bridge/Symfony/Container/Proxy/Generation/MethodGenerator/Util/PublicScopeSimulator.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Proxy\Generation\MethodGenerator\Util;
+
+use InvalidArgumentException;
+use Laminas\Code\Generator\PropertyGenerator;
+use ReflectionClass;
+
+use function array_filter;
+use function array_map;
+use function implode;
+use function sprintf;
+use function var_export;
+
+/**
+ * Generates code necessary to simulate a fatal error in case of unauthorized
+ * access to class members in magic methods even when in child classes and dealing
+ * with protected members.
+ */
+final class PublicScopeSimulator
+{
+    public const string OPERATION_SET = 'set';
+    public const string OPERATION_GET = 'get';
+    public const string OPERATION_ISSET = 'isset';
+    public const string OPERATION_UNSET = 'unset';
+
+    /**
+     * Generates code for simulating access to a property from the scope that is accessing a proxy.
+     * This is done by introspecting `debug_backtrace()` and then binding a closure to the scope
+     * of the parent caller.
+     *
+     * @param string $operationType operation to execute: one of 'get', 'set', 'isset' or 'unset'
+     * @param string $nameParameter name of the `name` parameter of the magic method
+     * @param string|null $valueParameter name of the `value` parameter of the magic method, only to be
+     *                                              used with $operationType 'set'
+     * @param PropertyGenerator $valueHolder name of the property containing the target object from which
+     *                                              to read the property. `$this` if none provided
+     * @param string|null $returnPropertyName name of the property to which we want to assign the result of
+     *                                              the operation. Return directly if none provided
+     * @param ReflectionClass<object>|null $originalClass reflection of the original class if available
+     * @psalm-param $operationType self::OPERATION_*
+     * @throws InvalidArgumentException
+     */
+    public static function getPublicAccessSimulationCode(
+        string $operationType,
+        string $nameParameter,
+        ?string $valueParameter = null,
+        ?PropertyGenerator $valueHolder = null,
+        ?string $returnPropertyName = null,
+        ?ReflectionClass $originalClass = null,
+    ): string {
+        $byRef = self::getByRefReturnValue($operationType);
+        $target = '$this';
+
+        if ($valueHolder) {
+            $target = '$this->' . $valueHolder->getName();
+        }
+
+        $originalClassReflection = $originalClass === null
+            ? 'new \\ReflectionClass(get_parent_class($this))'
+            : 'new \\ReflectionClass(' . var_export($originalClass->getName(), true) . ')';
+
+        $accessorEvaluation = $returnPropertyName
+            ? '$' . $returnPropertyName . ' = ' . $byRef . '$accessor();'
+            : '$returnValue = ' . $byRef . '$accessor();' . "\n\n" . 'return $returnValue;';
+
+        if ($operationType === self::OPERATION_UNSET) {
+            $accessorEvaluation = '$accessor();';
+        }
+
+        return '$realInstanceReflection = ' . $originalClassReflection . ';' . "\n\n"
+            . 'if (! $realInstanceReflection->hasProperty($' . $nameParameter . ')) {' . "\n"
+            . '    $targetObject = ' . $target . ';' . "\n\n"
+            . self::getUndefinedPropertyNotice($operationType, $nameParameter)
+            . '    ' . self::getOperation($operationType, $nameParameter, $valueParameter) . "\n"
+            . '}' . "\n\n"
+            . '$targetObject = ' . self::getTargetObject($valueHolder) . ";\n"
+            . '$accessor = function ' . $byRef . '() use ('
+            . implode(', ', array_map(
+                static fn(string $parameterName): string => '$' . $parameterName,
+                array_filter(['targetObject', $nameParameter, $valueParameter])
+            ))
+            . ') {' . "\n"
+            . '    ' . self::getOperation($operationType, $nameParameter, $valueParameter) . "\n"
+            . "};\n"
+            . self::generateScopeReBind()
+            . $accessorEvaluation;
+    }
+
+    /**
+     * This will generate code that triggers a notice if access is attempted on a non-existing property
+     *
+     * @psalm-param $operationType self::OPERATION_*
+     */
+    private static function getUndefinedPropertyNotice(
+        string $operationType,
+        string $nameParameter,
+        ?string $interfaceName = null,
+    ): string {
+        if ($operationType !== self::OPERATION_GET) {
+            return '';
+        }
+
+        $code = '    $backtrace = debug_backtrace(false, 1);' . "\n"
+            . '    trigger_error(' . "\n"
+            . '        sprintf(' . "\n"
+            . '            \'Undefined property: %s::$%s in %s on line %s\',' . "\n"
+            . '            $realInstanceReflection->getName(),' . "\n"
+            . '            $' . $nameParameter . ',' . "\n"
+            . '            $backtrace[0][\'file\'],' . "\n"
+            . '            $backtrace[0][\'line\']' . "\n"
+            . '        ),' . "\n"
+            . '        \E_USER_NOTICE' . "\n"
+            . '    );' . "\n";
+
+        if ($interfaceName !== null) {
+            $code = str_replace("\n    ", "\n", substr($code, 4));
+        }
+
+        return $code;
+    }
+
+    /**
+     * Defines whether the given operation produces a reference.
+     *
+     * Note: if the object is a wrapper, the wrapped instance is accessed directly. If the object
+     * is a ghost or the proxy has no wrapper, then an instance of the parent class is created via
+     * on-the-fly unserialization
+     *
+     * @psalm-param $operationType self::OPERATION_*
+     */
+    private static function getByRefReturnValue(string $operationType): string
+    {
+        return $operationType === self::OPERATION_GET || $operationType === self::OPERATION_SET ? '& ' : '';
+    }
+
+    /**
+     * Retrieves the logic to fetch the object on which access should be attempted
+     */
+    private static function getTargetObject(?PropertyGenerator $valueHolder = null): string
+    {
+        if ($valueHolder) {
+            return '$this->' . $valueHolder->getName();
+        }
+
+        return '$realInstanceReflection->newInstanceWithoutConstructor()';
+    }
+
+    /**
+     * @psalm-param $operationType self::OPERATION_*
+     * @throws InvalidArgumentException
+     */
+    private static function getOperation(string $operationType, string $nameParameter, ?string $valueParameter): string
+    {
+        if ($valueParameter !== null && $operationType !== self::OPERATION_SET) {
+            throw new InvalidArgumentException(
+                'Parameter $valueParameter should be provided (only) when $operationType === "'
+                . self::OPERATION_SET . '"'
+                . self::class
+                . '::OPERATION_SET'
+            );
+        }
+
+        switch ($operationType) {
+            case self::OPERATION_GET:
+                return 'return $targetObject->$' . $nameParameter . ';';
+            case self::OPERATION_SET:
+                if ($valueParameter === null) {
+                    throw new InvalidArgumentException(
+                        'Parameter $valueParameter should be provided (only) when $operationType === "'
+                        . self::OPERATION_SET . '"'
+                        . self::class
+                        . '::OPERATION_SET'
+                    );
+                }
+
+                return '$targetObject->$' . $nameParameter . ' = $' . $valueParameter . ';'
+                    . "\n\n"
+                    . '    return $targetObject->$' . $nameParameter . ';';
+            case self::OPERATION_ISSET:
+                return 'return isset($targetObject->$' . $nameParameter . ');';
+            case self::OPERATION_UNSET:
+                return 'unset($targetObject->$' . $nameParameter . ');'
+                    . "\n\n"
+                    . '    return;';
+        }
+
+        throw new InvalidArgumentException(sprintf('Invalid operation "%s" provided', $operationType));
+    }
+
+    /**
+     * Generates code to bind operations to the parent scope
+     */
+    private static function generateScopeReBind(): string
+    {
+        return '$accessor = $accessor->bindTo($targetObject, get_class($targetObject));' . "\n\n";
+    }
+}

--- a/src/Bridge/Symfony/Container/Proxy/UnmanagedFactoryInstantiator.php
+++ b/src/Bridge/Symfony/Container/Proxy/UnmanagedFactoryInstantiator.php
@@ -12,6 +12,7 @@ use RuntimeException;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Initializer;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Resetter;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\ServicePoolContainer;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\ServicePoolEntry;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool\UnmanagedFactoryServicePool;
 use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
 use SwooleBundle\SwooleBundle\Component\Locking\MutexFactory;
@@ -109,10 +110,9 @@ final readonly class UnmanagedFactoryInstantiator
                     $swoole,
                     $limitMutex,
                     $instancesLimit,
-                    $resetter,
                     $initializer,
                 );
-                $servicePoolContainer->addPool($servicePool);
+                $servicePoolContainer->addPoolEntry(new ServicePoolEntry($servicePool, $resetter));
 
                 return $instantiator->newInstance($servicePool, $factoryConfig['returnType']);
             };

--- a/src/Bridge/Symfony/Container/ServicePool/BaseServicePool.php
+++ b/src/Bridge/Symfony/Container/ServicePool/BaseServicePool.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool;
 
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Initializer;
-use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Resetter;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\StabilityChecker;
 use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
 use SwooleBundle\SwooleBundle\Component\Locking\Mutex;
@@ -32,7 +31,6 @@ abstract class BaseServicePool implements ServicePool
         private readonly Swoole $swoole,
         private readonly Mutex $mutex,
         private readonly int $instancesLimit = 50,
-        private readonly ?Resetter $resetter = null,
         private readonly ?StabilityChecker $stabilityChecker = null,
         private readonly ?Initializer $initializer = null,
     ) {}
@@ -58,8 +56,17 @@ abstract class BaseServicePool implements ServicePool
         return $this->assignedPool[$cId] = $this->getServiceToAssign();
     }
 
-    public function releaseFromCoroutine(int $cId): void
+    public function getAssigned(): ?object
     {
+        $cId = $this->getCoroutineId();
+
+        return $this->assignedPool[$cId] ?? null;
+    }
+
+    public function releaseFromCoroutine(): void
+    {
+        $cId = $this->getCoroutineId();
+
         if (!isset($this->assignedPool[$cId])) {
             return;
         }
@@ -73,8 +80,6 @@ abstract class BaseServicePool implements ServicePool
 
             return;
         }
-
-        $this->resetter?->reset($service);
 
         $this->freePool[] = $service;
         $this->unlockPool();

--- a/src/Bridge/Symfony/Container/ServicePool/DiServicePool.php
+++ b/src/Bridge/Symfony/Container/ServicePool/DiServicePool.php
@@ -6,7 +6,6 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool;
 
 use RuntimeException;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Initializer;
-use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Resetter;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\StabilityChecker;
 use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
 use SwooleBundle\SwooleBundle\Component\Locking\Mutex;
@@ -24,11 +23,10 @@ final class DiServicePool extends BaseServicePool
         Swoole $swoole,
         Mutex $mutex,
         int $instancesLimit = 50,
-        ?Resetter $resetter = null,
         ?StabilityChecker $stabilityChecker = null,
         ?Initializer $initializer = null,
     ) {
-        parent::__construct($swoole, $mutex, $instancesLimit, $resetter, $stabilityChecker, $initializer);
+        parent::__construct($swoole, $mutex, $instancesLimit, $stabilityChecker, $initializer);
     }
 
     /**

--- a/src/Bridge/Symfony/Container/ServicePool/ServicePool.php
+++ b/src/Bridge/Symfony/Container/ServicePool/ServicePool.php
@@ -14,5 +14,7 @@ interface ServicePool
      */
     public function get(): object;
 
-    public function releaseFromCoroutine(int $cId): void;
+    public function getAssigned(): ?object;
+
+    public function releaseFromCoroutine(): void;
 }

--- a/src/Bridge/Symfony/Container/ServicePool/ServicePoolContainer.php
+++ b/src/Bridge/Symfony/Container/ServicePool/ServicePoolContainer.php
@@ -7,34 +7,71 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool;
 final class ServicePoolContainer
 {
     /**
-     * @param array<int, array<ServicePool<object>>> $pools
+     * @var array<int, ServicePoolEntry<object>>
      */
-    public function __construct(private array $pools) {}
+    private array $poolEntries = [];
 
     /**
-     * @param ServicePool<object> $pool
+     * @var array<int, array<int, ServicePoolEntry<object>>>
      */
-    public function addPool(ServicePool $pool, int $priority = 0): void
+    private array $poolEntriesToReset = [];
+
+    /**
+     * @param array<int, ServicePoolEntry<object>> $poolEntries
+     */
+    public function __construct(array $poolEntries)
     {
-        $this->pools[$priority][] = $pool;
-        krsort($this->pools);
+        foreach ($poolEntries as $poolEntry) {
+            $this->addPoolEntry($poolEntry);
+        }
     }
 
-    public function releaseFromCoroutine(int $cId): void
+    /**
+     * @param ServicePoolEntry<object> $poolEntry
+     */
+    public function addPoolEntry(ServicePoolEntry $poolEntry): void
     {
-        foreach ($this->pools as $poolsWithPriority) {
-            foreach ($poolsWithPriority as $pool) {
-                $pool->releaseFromCoroutine($cId);
+        $this->poolEntries[] = $poolEntry;
+
+        if ($poolEntry->resetter === null) {
+            return;
+        }
+
+        if (!isset($this->poolEntriesToReset[$poolEntry->resetPriority])) {
+            $this->poolEntriesToReset[$poolEntry->resetPriority] = [];
+        }
+
+        $this->poolEntriesToReset[$poolEntry->resetPriority][] = $poolEntry;
+    }
+
+    public function releaseFromCoroutine(): void
+    {
+        // the reset cycle has to be executed before releasing the services back to the pool
+        // to not get assigned too early to other coroutines which can cause deadlocks
+        // during the reset cycle if there are dependencies among released and not released services
+        foreach ($this->poolEntriesToReset as $prioritizedPoolEntries) {
+            foreach ($prioritizedPoolEntries as $poolEntry) {
+                if ($poolEntry->resetter === null) {
+                    continue;
+                }
+
+                $instance = $poolEntry->pool->getAssigned();
+
+                if ($instance === null) {
+                    continue;
+                }
+
+                $poolEntry->resetter->reset($instance);
             }
+        }
+
+        foreach ($this->poolEntries as $poolEntry) {
+            $poolEntry->pool->releaseFromCoroutine();
         }
     }
 
     public function count(): int
     {
-        return array_reduce(
-            $this->pools,
-            static fn(int $count, array $poolsWithPriority): int => $count + count($poolsWithPriority),
-            0,
-        );
+        return count($this->poolEntries);
     }
 }

--- a/src/Bridge/Symfony/Container/ServicePool/ServicePoolEntry.php
+++ b/src/Bridge/Symfony/Container/ServicePool/ServicePoolEntry.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool;
+
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Resetter;
+
+/**
+ * @template T of object
+ */
+final readonly class ServicePoolEntry
+{
+    /**
+     * @param ServicePool<T> $pool
+     */
+    public function __construct(
+        public ServicePool $pool,
+        public ?Resetter $resetter = null,
+        public int $resetPriority = 0,
+    ) {}
+}

--- a/src/Bridge/Symfony/Container/ServicePool/UnmanagedFactoryServicePool.php
+++ b/src/Bridge/Symfony/Container/ServicePool/UnmanagedFactoryServicePool.php
@@ -6,7 +6,6 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Container\ServicePool;
 
 use Closure;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Initializer;
-use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Resetter;
 use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
 use SwooleBundle\SwooleBundle\Component\Locking\Mutex;
 
@@ -24,10 +23,9 @@ final class UnmanagedFactoryServicePool extends BaseServicePool
         Swoole $swoole,
         Mutex $mutex,
         int $instancesLimit = 50,
-        ?Resetter $resetter = null,
         ?Initializer $initializer = null,
     ) {
-        parent::__construct($swoole, $mutex, $instancesLimit, $resetter, null, $initializer);
+        parent::__construct($swoole, $mutex, $instancesLimit, null, $initializer);
     }
 
     /**

--- a/src/Bridge/Symfony/Router/RouterProcessor.php
+++ b/src/Bridge/Symfony/Router/RouterProcessor.php
@@ -19,9 +19,9 @@ final class RouterProcessor implements CompileProcessor
             return;
         }
 
-        // the debug event dispatcher needs to be coupled to the original event dispatcher, because
+        // the debug event dispatcher needs to be proxified
         // it registers listeners to the original dispatcher
-        $dispatcherDef = $container->findDefinition('debug.event_dispatcher.inner');
-        $dispatcherDef->setShared(false);
+        // for yet unknown reason the debug.event_dispatcher has to be proxified in StatefulServicesPass
+        $proxifier->proxifyService('debug.event_dispatcher.inner');
     }
 }

--- a/tests/Feature/BlackfireProfilerRegisteredTest.php
+++ b/tests/Feature/BlackfireProfilerRegisteredTest.php
@@ -16,7 +16,7 @@ final class BlackfireProfilerRegisteredTest extends ServerTestCase
      */
     public function testWiring(): void
     {
-        $kernel = self::createKernel(['environment' => 'dev']);
+        $kernel = self::createKernel(['environment' => 'blackfire']);
         $kernel->boot();
 
         $container = $kernel->getContainer();

--- a/tests/Fixtures/Symfony/TestBundle/DependencyInjection/CompilerPass/CounterCompileProcessor.php
+++ b/tests/Fixtures/Symfony/TestBundle/DependencyInjection/CompilerPass/CounterCompileProcessor.php
@@ -32,6 +32,7 @@ final class CounterCompileProcessor implements CompileProcessor
         $counterDef = new Definition();
         $counterDef->setClass(CountingInitializer::class);
         $counterDef->setArgument(0, new Reference($newId));
+        $counterDef->addTag('swoole_bundle.safe_stateful_service');
         $container->setDefinition($initializerId, $counterDef);
 
         $controllerDef = $container->findDefinition(DoctrineController::class);
@@ -49,6 +50,7 @@ final class CounterCompileProcessor implements CompileProcessor
         $counterDef = new Definition();
         $counterDef->setClass(CountingResetter::class);
         $counterDef->setArgument(0, new Reference($newId));
+        $counterDef->addTag('swoole_bundle.safe_stateful_service');
         $container->setDefinition($resetterId, $counterDef);
 
         $controllerDef = $container->findDefinition(DoctrineController::class);

--- a/tests/Fixtures/Symfony/app/config/blackfire/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/blackfire/swoole.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'services' => [
+                'blackfire_profiler' => true,
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/coroutines/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/coroutines/swoole.php
@@ -27,10 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $containerConfigurator->extension('swoole', [
         'http_server' => [
-            'static' => [
-                'strategy' => 'advanced',
-                'public_dir' => '%kernel.project_dir%/public',
-            ],
+            'static' => 'default',
             'exception_handler' => [
                 'type' => 'symfony',
             ],

--- a/tests/Fixtures/Symfony/app/config/monolog.php
+++ b/tests/Fixtures/Symfony/app/config/monolog.php
@@ -11,6 +11,7 @@ $handlers = [
         'path' => '%kernel.logs_dir%/%kernel.environment%.log',
         'level' => 'warning',
         'channels' => ['!event'],
+        'formatter' => 'monolog.formatter.full_trace',
     ],
 ];
 

--- a/tests/Fixtures/Symfony/app/config/services.php
+++ b/tests/Fixtures/Symfony/app/config/services.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use Monolog\Formatter\LineFormatter;
 use Ramsey\Uuid\UuidFactory;
 use Ramsey\Uuid\UuidFactoryInterface;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\SimpleResetter;
 use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Controller\DoctrineController;
 use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Controller\SleepController;
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\EventHandler\LifecycleEventsEventHandler;
 use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Service\AdvancedDoctrineUsage;
 use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Service\DecorationTestDummyService;
 use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Service\DefaultDummyService;
@@ -86,4 +88,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->tag('kernel.reset', [
             'method' => 'reset',
         ]);
+
+    $services->set(LifecycleEventsEventHandler::class)
+        ->tag('swoole_bundle.stateful_service');
+
+    $services->set('monolog.formatter.full_trace', LineFormatter::class)
+        ->arg('$format', null)
+        ->arg('$dateFormat', null)
+        ->arg('$allowInlineLineBreaks', true)
+        ->arg('$ignoreEmptyContextAndExtra', false)
+        ->arg('$includeStacktraces', true);
 };


### PR DESCRIPTION
This PR removes identified unsecure code areas that have their data accessed by concurrent coroutines.
All the related services were either proxified or updated to not use shareable variables.

Also there is a fix for monolog stream handler in this regard 
and fix for OSX and debug mode, with DebugClassLoader.

Also - this PR fixes a bug with service resetting. The mechanism is about at first doing all the resets and release service instances to the service pools after everything has been reset. This way it cannot happen that concurrent coroutine will steal a service instance that won't be able to get reset from its wrapper service.