### PR TITLE
feat(coroutines): isolate error and exception handlers per coroutine

### DIFF
--- a/src/Bridge/Symfony/Bundle/SwooleBundle.php
+++ b/src/Bridge/Symfony/Bundle/SwooleBundle.php
@@ -6,6 +6,7 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle;
 
 use Assert\Assertion;
 use RuntimeException;
+use SwooleBundle\SwooleBundle\Bridge\CommonSwoole\SystemSwooleFactory;
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass\{BlackfireMonitoringPass,
     CacheWarmupFixerPass,
     ExceptionHandlerPass,
@@ -17,6 +18,7 @@ use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\Compiler
     StreamedResponseListenerPass,
     SwooleTableStorageConfiguratorPass};
 use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\ContainerConstants;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\ErrorHandler\ContextualErrorHandler;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ErrorHandler\ErrorHandler;
@@ -62,6 +64,9 @@ final class SwooleBundle extends Bundle
         if (!$this->container->getParameter(ContainerConstants::PARAM_COROUTINES_ENABLED)) {
             return;
         }
+
+        // from now on, error/exception handler overrides are isolated per coroutine
+        ContextualErrorHandler::register(SystemSwooleFactory::newFactoryInstance()->newInstance());
 
         /** @var ErrorHandler $handler */
         $handler = $this->container->get('swoole_bundle.error_handler.symfony_error_handler');

--- a/src/Bridge/Symfony/ErrorHandler/ContextualErrorHandler.php
+++ b/src/Bridge/Symfony/ErrorHandler/ContextualErrorHandler.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Bridge\Symfony\ErrorHandler;
+
+use Co;
+use ReflectionFunction as NativeReflectionFunction;
+use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
+use Throwable;
+use ZEngine\Reflection\ReflectionFunction;
+
+/**
+ * Coroutine aware replacement of the PHP error and exception handler registry.
+ *
+ * PHP keeps a single, process wide stack of error/exception handlers. With coroutines enabled that
+ * stack is shared by all requests handled concurrently in the same worker, so any code temporarily
+ * overriding a handler (and restoring it afterwards) silently corrupts the handler of every other
+ * coroutine running in the meantime.
+ *
+ * Once registered, set_error_handler(), set_exception_handler(), restore_error_handler() and
+ * restore_exception_handler() are redefined to keep a separate handler stack per coroutine.
+ * Handlers registered outside of a coroutine (for example during kernel boot) form the global
+ * stack, which is used as a fallback by every coroutine that did not override them.
+ */
+final class ContextualErrorHandler
+{
+    /**
+     * Coroutine id reported when running outside of a coroutine.
+     */
+    private const int GLOBAL_CONTEXT_ID = -1;
+
+    private static ?self $instance = null;
+
+    /**
+     * @var array<int, list<array{0: callable|null, 1: int}>>
+     */
+    private array $errorHandlers = [];
+
+    /**
+     * @var array<int, list<callable|null>>
+     */
+    private array $exceptionHandlers = [];
+
+    /**
+     * @var array<int, bool>
+     */
+    private array $deferredCleanups = [];
+
+    private function __construct(
+        private readonly Swoole $swoole,
+    ) {}
+
+    /**
+     * Takes over the PHP error/exception handler registry. Handlers registered before this call are
+     * kept as the global fallback. Calling it more than once is a no-op.
+     */
+    public static function register(Swoole $swoole, int $errorLevels = E_ALL): void
+    {
+        if (self::$instance !== null) {
+            return;
+        }
+
+        $instance = new self($swoole);
+        self::$instance = $instance;
+
+        $previousErrorHandler = set_error_handler([$instance, 'handleError'], $errorLevels);
+        $previousExceptionHandler = set_exception_handler([$instance, 'handleException']);
+
+        if ($previousErrorHandler !== null) {
+            $instance->setErrorHandler($previousErrorHandler, $errorLevels);
+        }
+
+        if ($previousExceptionHandler !== null) {
+            $instance->setExceptionHandler($previousExceptionHandler);
+        }
+
+        self::redefineHandlerFunctions();
+    }
+
+    /**
+     * Registered as the one and only real PHP error handler, dispatches to the handler of the
+     * current coroutine.
+     */
+    public function handleError(int $type, string $message, string $file, int $line): bool
+    {
+        [$handler, $errorLevels] = $this->currentErrorHandler();
+
+        if ($handler === null || ($errorLevels & $type) === 0) {
+            // let the internal PHP error handler take over
+            return false;
+        }
+
+        return $handler($type, $message, $file, $line) !== false;
+    }
+
+    /**
+     * Registered as the one and only real PHP exception handler, dispatches to the handler of the
+     * current coroutine.
+     */
+    public function handleException(Throwable $exception): void
+    {
+        $handler = $this->currentExceptionHandler();
+
+        if ($handler === null) {
+            throw $exception;
+        }
+
+        $handler($exception);
+    }
+
+    /**
+     * @return callable|null the handler which was effective for the current coroutine before
+     */
+    public function setErrorHandler(?callable $callback, int $errorLevels = E_ALL): ?callable
+    {
+        $contextId = $this->contextId();
+        [$previous] = $this->currentErrorHandler();
+        $this->errorHandlers[$contextId][] = [$callback, $errorLevels];
+        $this->deferContextCleanup($contextId);
+
+        return $previous;
+    }
+
+    /**
+     * A coroutine can only restore handlers it registered itself, it can never pop the global stack.
+     */
+    public function restoreErrorHandler(): void
+    {
+        $contextId = $this->contextId();
+
+        if (($this->errorHandlers[$contextId] ?? []) === []) {
+            return;
+        }
+
+        array_pop($this->errorHandlers[$contextId]);
+    }
+
+    public function getErrorHandler(): ?callable
+    {
+        return $this->currentErrorHandler()[0];
+    }
+
+    /**
+     * @return callable|null the handler which was effective for the current coroutine before
+     */
+    public function setExceptionHandler(?callable $callback): ?callable
+    {
+        $contextId = $this->contextId();
+        $previous = $this->currentExceptionHandler();
+        $this->exceptionHandlers[$contextId][] = $callback;
+        $this->deferContextCleanup($contextId);
+
+        return $previous;
+    }
+
+    /**
+     * A coroutine can only restore handlers it registered itself, it can never pop the global stack.
+     */
+    public function restoreExceptionHandler(): void
+    {
+        $contextId = $this->contextId();
+
+        if (($this->exceptionHandlers[$contextId] ?? []) === []) {
+            return;
+        }
+
+        array_pop($this->exceptionHandlers[$contextId]);
+    }
+
+    public function getExceptionHandler(): ?callable
+    {
+        return $this->currentExceptionHandler();
+    }
+
+    private static function instance(): self
+    {
+        if (self::$instance === null) {
+            throw UnregisteredContextualErrorHandler::notRegisteredYet();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * The redefined closures have to be signature compatible with the functions they replace,
+     * which is why the original parameter names are used here.
+     */
+    private static function redefineHandlerFunctions(): void
+    {
+        // phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter
+        (new ReflectionFunction('set_error_handler'))->redefine(
+            static fn(?callable $callback, int $error_levels = E_ALL) // phpcs:ignore
+                => self::instance()->setErrorHandler($callback, $error_levels),
+        );
+
+        (new ReflectionFunction('set_exception_handler'))->redefine(
+            static fn(?callable $callback) => self::instance()->setExceptionHandler($callback),
+        );
+        // phpcs:enable SlevomatCodingStandard.Functions.UnusedParameter
+
+        (new ReflectionFunction('restore_error_handler'))->redefine(static function (): true {
+            self::instance()->restoreErrorHandler();
+
+            return true;
+        });
+
+        (new ReflectionFunction('restore_exception_handler'))->redefine(static function (): true {
+            self::instance()->restoreExceptionHandler();
+
+            return true;
+        });
+
+        // php 8.5+ provides these natively, on older versions the symfony polyfill implements them
+        // on top of the set_*()/restore_*() pair, which is contextual already
+        if (self::isNativeFunction('get_error_handler')) {
+            (new ReflectionFunction('get_error_handler'))->redefine(
+                static fn(): ?callable => self::instance()->getErrorHandler(),
+            );
+        }
+
+        if (!self::isNativeFunction('get_exception_handler')) {
+            return;
+        }
+
+        (new ReflectionFunction('get_exception_handler'))->redefine(
+            static fn(): ?callable => self::instance()->getExceptionHandler(),
+        );
+    }
+
+    private static function isNativeFunction(string $functionName): bool
+    {
+        return function_exists($functionName) && (new NativeReflectionFunction($functionName))->isInternal();
+    }
+
+    /**
+     * @return array{0: callable|null, 1: int}
+     */
+    private function currentErrorHandler(): array
+    {
+        $stack = $this->errorHandlerStack();
+
+        return $stack === [] ? [null, 0] : $stack[array_key_last($stack)];
+    }
+
+    private function currentExceptionHandler(): ?callable
+    {
+        $contextId = $this->contextId();
+        $stack = $this->exceptionHandlers[$contextId] ?? [];
+
+        if ($stack === [] && $contextId !== self::GLOBAL_CONTEXT_ID) {
+            $stack = $this->exceptionHandlers[self::GLOBAL_CONTEXT_ID] ?? [];
+        }
+
+        return $stack === [] ? null : $stack[array_key_last($stack)];
+    }
+
+    /**
+     * @return list<array{0: callable|null, 1: int}>
+     */
+    private function errorHandlerStack(): array
+    {
+        $contextId = $this->contextId();
+        $stack = $this->errorHandlers[$contextId] ?? [];
+
+        if ($stack === [] && $contextId !== self::GLOBAL_CONTEXT_ID) {
+            return $this->errorHandlers[self::GLOBAL_CONTEXT_ID] ?? [];
+        }
+
+        return $stack;
+    }
+
+    /**
+     * Drops the overrides of a coroutine when it finishes, so the next coroutine reusing the same id
+     * starts from the global handlers again. Registered as late as possible - the very first time a
+     * coroutine overrides a handler - which covers coroutines started by a plain go() as well.
+     */
+    private function deferContextCleanup(int $contextId): void
+    {
+        if ($contextId === self::GLOBAL_CONTEXT_ID || isset($this->deferredCleanups[$contextId])) {
+            return;
+        }
+
+        $this->deferredCleanups[$contextId] = true;
+
+        Co::defer(function (): void {
+            $this->clearCurrentContext();
+        });
+    }
+
+    private function clearCurrentContext(): void
+    {
+        $contextId = $this->contextId();
+
+        if ($contextId === self::GLOBAL_CONTEXT_ID) {
+            return;
+        }
+
+        unset(
+            $this->errorHandlers[$contextId],
+            $this->exceptionHandlers[$contextId],
+            $this->deferredCleanups[$contextId],
+        );
+    }
+
+    private function contextId(): int
+    {
+        return $this->swoole->getCoroutineId();
+    }
+}

--- a/src/Bridge/Symfony/ErrorHandler/UnregisteredContextualErrorHandler.php
+++ b/src/Bridge/Symfony/ErrorHandler/UnregisteredContextualErrorHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Bridge\Symfony\ErrorHandler;
+
+use RuntimeException;
+use Throwable;
+
+final class UnregisteredContextualErrorHandler extends RuntimeException
+{
+    private function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function notRegisteredYet(): self
+    {
+        return new self('ContextualErrorHandler was not registered yet.');
+    }
+}

--- a/src/Reflection/ClassModifier.php
+++ b/src/Reflection/ClassModifier.php
@@ -25,7 +25,7 @@ final class ClassModifier
 
     public static function initialize(string $cacheDir): void
     {
-        Core::init();
+        self::initializeZEngine();
         self::initializeCache($cacheDir);
         self::modifyStoredFinalClasses();
     }
@@ -62,6 +62,22 @@ final class ClassModifier
         $item = $cache->getItem(self::CACHE_KEY_FINAL_CLASSES);
         $item->set(self::$originalFinalClasses);
         $cache->save($item);
+    }
+
+    /**
+     * The kernel can be booted more than once per process (cache:clear boots a temporary kernel of
+     * its own), but Core::init() is not idempotent - every call builds a brand new FFI binding and
+     * drops the previous one. Anything still pointing into the dropped binding, most notably the FFI
+     * callbacks installed by ReflectionFunction::redefine(), is invalidated by that and takes the
+     * process down with a segmentation fault the next time it is used.
+     */
+    private static function initializeZEngine(): void
+    {
+        if (isset(Core::$executor)) {
+            return;
+        }
+
+        Core::init();
     }
 
     private static function modifyStoredFinalClasses(): void

--- a/tests/Feature/SwooleServerCoroutinesTest.php
+++ b/tests/Feature/SwooleServerCoroutinesTest.php
@@ -637,6 +637,137 @@ final class SwooleServerCoroutinesTest extends ServerTestCase
     }
 
     /**
+     * @param array{
+     *    APP_ENV: string,
+     *    APP_DEBUG: string,
+     *    WORKER_COUNT: string,
+     *    REACTOR_COUNT: string,
+     *    OVERRIDE_PROD_ENV?: string,
+     *  } $envs
+     */
+    #[DataProvider('coroutineTestDataProvider')]
+    public function testErrorHandlersAreIsolatedPerCoroutine(array $envs): void
+    {
+        $this->startServerForCoroutineTest($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $initClient = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($initClient->connect(3, 1, true));
+
+            $wg = $this->getSwoole()->waitGroup();
+
+            for ($i = 0; $i < 5; ++$i) {
+                $marker = 'req' . $i;
+                go(function () use ($wg, $marker): void {
+                    $wg->add();
+                    $client = HttpClient::fromDomain('localhost', 9999, false);
+                    $this->assertTrue($client->connect(waitIfNoConnection: true));
+
+                    /** @var array{
+                     *    body: array{
+                     *      caught: array<string>,
+                     *      global_error_handler: string,
+                     *      global_exception_handler: string,
+                     *      own_error_handler: string,
+                     *      own_exception_handler: string,
+                     *      restored_error_handler: string,
+                     *      restored_exception_handler: string,
+                     *    },
+                     *    statusCode: int,
+                     *  } $response
+                     */
+                    $response = $client->send('/error-handler/contextual?marker=' . $marker)['response'];
+                    $this->assertSame(200, $response['statusCode']);
+
+                    $body = $response['body'];
+
+                    // all requests override the handlers while the others are still running, yet each
+                    // request may only ever see the errors it triggered itself
+                    $this->assertSame(
+                        [
+                            $marker . ':warning for ' . $marker,
+                            $marker . ':notice for ' . $marker,
+                        ],
+                        $body['caught'],
+                    );
+                    $this->assertSame('Closure', $body['own_error_handler']);
+                    $this->assertSame('Closure', $body['own_exception_handler']);
+
+                    // the handlers registered during kernel boot are never replaced by a coroutine
+                    $this->assertNotSame('Closure', $body['global_error_handler']);
+                    $this->assertNotSame('Closure', $body['global_exception_handler']);
+                    $this->assertSame($body['global_error_handler'], $body['restored_error_handler']);
+                    $this->assertSame($body['global_exception_handler'], $body['restored_exception_handler']);
+
+                    $wg->done();
+                });
+            }
+
+            $wg->wait(10);
+        });
+    }
+
+    /**
+     * @param array{
+     *    APP_ENV: string,
+     *    APP_DEBUG: string,
+     *    WORKER_COUNT: string,
+     *    REACTOR_COUNT: string,
+     *    OVERRIDE_PROD_ENV?: string,
+     *  } $envs
+     */
+    #[DataProvider('coroutineTestDataProvider')]
+    public function testOverriddenErrorHandlersAreClearedWhenCoroutineEnds(array $envs): void
+    {
+        $this->startServerForCoroutineTest($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $client = HttpClient::fromDomain('localhost', 9999, false);
+            $this->assertTrue($client->connect(3, 1, true));
+
+            for ($i = 0; $i < 5; ++$i) {
+                /**
+                 * @var array{
+                 *   body: array{error_handler: string, exception_handler: string},
+                 *   statusCode: int,
+                 * } $leaked
+                 */
+                $leaked = $client->send('/error-handler/leaking')['response'];
+                $this->assertSame(200, $leaked['statusCode']);
+                $this->assertSame('Closure', $leaked['body']['error_handler']);
+                $this->assertSame('Closure', $leaked['body']['exception_handler']);
+            }
+
+            // none of the requests above restored anything, the coroutine end had to do it for them.
+            // the coroutine serving this very request is allowed to have overrides of its own,
+            // symfony registers them while handling a request
+            /**
+             * @var array{
+             *   body: array{registered: bool, coroutine_id: int, tracked: array<int>},
+             *   statusCode: int,
+             * } $tracked
+             */
+            $tracked = $client->send('/error-handler/tracked-coroutines')['response'];
+            $this->assertSame(200, $tracked['statusCode']);
+            $this->assertTrue($tracked['body']['registered']);
+            $this->assertSame(
+                [],
+                array_values(array_diff($tracked['body']['tracked'], [$tracked['body']['coroutine_id']])),
+            );
+
+            /** @var array{body: array{error_handler: string, exception_handler: string}, statusCode: int} $current */
+            $current = $client->send('/error-handler/current')['response'];
+            $this->assertSame(200, $current['statusCode']);
+            $this->assertNotSame('Closure', $current['body']['error_handler']);
+            $this->assertNotSame('Closure', $current['body']['exception_handler']);
+        });
+    }
+
+    /**
      * @return array<array<array{
      *   APP_ENV: string,
      *   APP_DEBUG: string,
@@ -791,6 +922,40 @@ final class SwooleServerCoroutinesTest extends ServerTestCase
             [['environment' => 'coroutines', 'debug' => false]],
             [['environment' => 'coroutines', 'debug' => true]],
         ];
+    }
+
+    /**
+     * @param array{
+     *    APP_ENV: string,
+     *    APP_DEBUG: string,
+     *    WORKER_COUNT: string,
+     *    REACTOR_COUNT: string,
+     *    OVERRIDE_PROD_ENV?: string,
+     *  } $envs
+     */
+    private function startServerForCoroutineTest(array $envs): void
+    {
+        $clearCache = $this->createConsoleProcess(['cache:clear'], $envs);
+        $clearCache->setTimeout(5);
+        $clearCache->disableOutput();
+        $clearCache->run();
+
+        $this->assertProcessSucceeded($clearCache);
+
+        $serverStart = $this->createConsoleProcess(
+            [
+                'swoole:server:start',
+                '--host=localhost',
+                '--port=9999',
+            ],
+            $envs
+        );
+
+        $serverStart->setTimeout(5);
+        $serverStart->disableOutput();
+        $serverStart->run();
+
+        $this->assertProcessSucceeded($serverStart);
     }
 
     private function generateNotExistingCustomTestFile(): string

--- a/tests/Fixtures/Symfony/TestBundle/Controller/ErrorHandlerController.php
+++ b/tests/Fixtures/Symfony/TestBundle/Controller/ErrorHandlerController.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Controller;
+
+use ArrayObject;
+use ReflectionProperty;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\ErrorHandler\ContextualErrorHandler;
+use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
+
+final readonly class ErrorHandlerController
+{
+    /**
+     * Coroutine id used by the handler for everything registered outside of a coroutine.
+     */
+    private const int GLOBAL_CONTEXT_ID = -1;
+
+    public function __construct(
+        private Swoole $swoole,
+    ) {}
+
+    /**
+     * Overrides the error/exception handler, yields a few times so concurrently handled requests do
+     * the very same thing, and finally restores the handlers it registered.
+     */
+    #[Route(path: '/error-handler/contextual', methods: ['GET'])]
+    public function contextual(Request $request): JsonResponse
+    {
+        $marker = (string) $request->query->get('marker', 'default');
+        $sleepMicroseconds = (int) $request->query->get('sleep', 50_000);
+        /** @var ArrayObject<int, string> $caught */
+        $caught = new ArrayObject();
+
+        $globalErrorHandler = self::currentErrorHandler();
+        $globalExceptionHandler = self::currentExceptionHandler();
+
+        set_error_handler(static function (int $type, string $message) use ($caught, $marker): bool {
+            $caught->append($marker . ':' . $message);
+
+            return true;
+        });
+        set_exception_handler(static function (Throwable $throwable) use ($caught, $marker): void {
+            $caught->append($marker . ':' . $throwable->getMessage());
+        });
+
+        $ownErrorHandler = self::currentErrorHandler();
+        $ownExceptionHandler = self::currentExceptionHandler();
+
+        // yield, so the other concurrently handled requests get a chance to override the handlers too
+        usleep($sleepMicroseconds);
+        trigger_error('warning for ' . $marker, E_USER_WARNING);
+
+        usleep($sleepMicroseconds);
+        trigger_error('notice for ' . $marker, E_USER_NOTICE);
+
+        restore_error_handler();
+        restore_exception_handler();
+
+        return new JsonResponse([
+            'caught' => $caught->getArrayCopy(),
+            'coroutine_id' => $this->swoole->getCoroutineId(),
+            'global_error_handler' => $globalErrorHandler,
+            'global_exception_handler' => $globalExceptionHandler,
+            'own_error_handler' => $ownErrorHandler,
+            'own_exception_handler' => $ownExceptionHandler,
+            'restored_error_handler' => self::currentErrorHandler(),
+            'restored_exception_handler' => self::currentExceptionHandler(),
+        ]);
+    }
+
+    /**
+     * Overrides both handlers without ever restoring them, the coroutine end has to clean up after it.
+     */
+    #[Route(path: '/error-handler/leaking', methods: ['GET'])]
+    public function leaking(): JsonResponse
+    {
+        set_error_handler(static fn(int $type, string $message): bool => true);
+        set_exception_handler(static function (Throwable $throwable): void {});
+
+        return $this->current();
+    }
+
+    #[Route(path: '/error-handler/current', methods: ['GET'])]
+    public function current(): JsonResponse
+    {
+        return new JsonResponse([
+            'coroutine_id' => $this->swoole->getCoroutineId(),
+            'error_handler' => self::currentErrorHandler(),
+            'exception_handler' => self::currentExceptionHandler(),
+        ]);
+    }
+
+    /**
+     * Exposes the coroutine ids the handler still keeps overrides for, so a test can prove that
+     * finished coroutines do not pile up in the handler registry.
+     */
+    #[Route(path: '/error-handler/tracked-coroutines', methods: ['GET'])]
+    public function trackedCoroutines(): JsonResponse
+    {
+        $instance = (new ReflectionProperty(ContextualErrorHandler::class, 'instance'))->getValue();
+
+        if (!$instance instanceof ContextualErrorHandler) {
+            return new JsonResponse(['registered' => false, 'tracked' => []], 200);
+        }
+
+        $tracked = [];
+
+        foreach (['errorHandlers', 'exceptionHandlers', 'deferredCleanups'] as $property) {
+            /** @var array<int, mixed> $contexts */
+            $contexts = (new ReflectionProperty(ContextualErrorHandler::class, $property))->getValue($instance);
+
+            foreach (array_keys($contexts) as $contextId) {
+                if ($contextId === self::GLOBAL_CONTEXT_ID) {
+                    continue;
+                }
+
+                $tracked[$contextId] = $contextId;
+            }
+        }
+
+        sort($tracked);
+
+        return new JsonResponse([
+            'registered' => true,
+            'coroutine_id' => $this->swoole->getCoroutineId(),
+            'tracked' => $tracked,
+        ], 200);
+    }
+
+    private static function currentErrorHandler(): string
+    {
+        $handler = set_error_handler(null);
+        restore_error_handler();
+
+        return self::describeHandler($handler);
+    }
+
+    private static function currentExceptionHandler(): string
+    {
+        $handler = set_exception_handler(null);
+        restore_exception_handler();
+
+        return self::describeHandler($handler);
+    }
+
+    private static function describeHandler(mixed $handler): string
+    {
+        if (is_array($handler)) {
+            $target = $handler[0];
+
+            return (is_object($target) ? $target::class : (string) $target) . '::' . $handler[1];
+        }
+
+        return get_debug_type($handler);
+    }
+}


### PR DESCRIPTION
## Problem

PHP keeps a single process-wide stack of error/exception handlers. With coroutines enabled that stack is shared by every request handled concurrently in a worker, so any code that temporarily overrides a handler and restores it afterwards silently corrupts the handler of every other coroutine in flight.

## Solution

`ContextualErrorHandler` installs itself as the one real PHP error and exception handler and uses ZEngine to redefine `set_error_handler()`, `set_exception_handler()`, `restore_error_handler()` and `restore_exception_handler()`, so each coroutine gets its own handler stack.

- Handlers registered outside a coroutine (cid `-1`, i.e. kernel boot) form the global stack and act as the fallback for every coroutine that never overrode them.
- `restore_*()` inside a coroutine only pops that coroutine's own stack — it can never pop the global one.
- `get_error_handler()` / `get_exception_handler()` are redefined too on PHP 8.5, where they are internal. On 8.3/8.4 the Symfony polyfill builds them on top of `set_*()`/`restore_*()`, which is already contextual.
- The redefined closures are signature-compatible with the functions they replace (ZEngine's `ensureCompatibleClosure()` compares parameter names and return types), verified against PHP 8.3, 8.4 and 8.5.

`SwooleBundle::boot()` registers it just before Symfony's `ErrorHandler::register()`, so Symfony's own handlers land on the global stack.

## Coroutine-end cleanup

A `Co::defer()` cleanup is registered lazily, the first time a coroutine overrides a handler. That covers coroutines started by a plain `go()` which never go through `CoWrapper`, and a guard keeps it to exactly one defer per coroutine no matter how often the handlers are overridden. When the coroutine finishes its overrides are dropped, so the next coroutine reusing the same id starts from the global handlers again.

## Tests

`tests/Feature/SwooleServerCoroutinesTest.php`, with the `ErrorHandlerController` fixture:

- `testErrorHandlersAreIsolatedPerCoroutine` — 5 concurrent requests each override the handlers, yield, and trigger errors. Each request only ever sees its own errors, and restoring hands back the boot handlers.
- `testOverriddenErrorHandlersAreClearedWhenCoroutineEnds` — 5 requests leak their handlers on purpose. Afterwards no finished coroutine is still tracked and a later request sees the boot handlers again.

## Verification

Full `tests/Feature` suite on openswoole 26.2 / PHP 8.3: **OK (117 tests, 4381 assertions)**. phpstan (src + tests), phpcs and php-cs-fixer are clean.

The swoole 6.2 containers could not be used locally — they cannot run any coroutine sleep on this host (`Iouring::futex_wait() requires 6.7 or higher Linux kernel`), which also hangs the pre-existing `/sleep` endpoint on unmodified code. The swoole variants are covered by CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)