### PR TITLE
feat(coroutines): allow optional stateful services to skip proxification

### DIFF
--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/StatefulServicesPass.php
@@ -46,8 +46,15 @@ final class StatefulServicesPass implements CompilerPassInterface
         'router',
         'router.default',
         'request_stack',
-        'slugger',
         'swoole_bundle.error_handler.symfony_error_handler',
+    ];
+
+    /**
+     * Services which are proxified only when their definition allows it. Applications are free to redefine them
+     * in a way which cannot be proxified at all, in such a case the proxification is silently skipped.
+     */
+    private const array OPTIONAL_SERVICES_TO_PROXIFY = [
+        'slugger',
     ];
 
     private const array SERVICE_RESETTING_PRIORITIES = [
@@ -176,8 +183,10 @@ final class StatefulServicesPass implements CompilerPassInterface
             $configuredStatefulServices,
             array_keys($dataCollectorServices),
             self::MANDATORY_SERVICES_TO_PROXIFY,
+            self::OPTIONAL_SERVICES_TO_PROXIFY,
         );
         $servicesToProxify = array_unique($servicesToProxify);
+        $optionalServices = array_flip(self::OPTIONAL_SERVICES_TO_PROXIFY);
 
         foreach ($servicesToProxify as $serviceId) {
             if (isset(self::IGNORED_SERVICES[$serviceId])) {
@@ -185,6 +194,10 @@ final class StatefulServicesPass implements CompilerPassInterface
             }
 
             if (!$container->has($serviceId)) {
+                continue;
+            }
+
+            if (isset($optionalServices[$serviceId]) && !$this->isOptionalServiceProxifiable($container, $serviceId)) {
                 continue;
             }
 
@@ -209,6 +222,17 @@ final class StatefulServicesPass implements CompilerPassInterface
             $resetPriority = self::SERVICE_RESETTING_PRIORITIES[$serviceId] ?? 0;
             $proxifier->proxifyService($serviceId, $resetter, $resetPriority);
         }
+    }
+
+    /**
+     * A service cannot be proxified when there is no concrete class to generate the proxy from, which happens
+     * when the service definition class is an interface or when it is not known at all.
+     */
+    private function isOptionalServiceProxifiable(ContainerBuilder $container, string $serviceId): bool
+    {
+        $definitionClass = $container->findDefinition($serviceId)->getClass();
+
+        return $definitionClass !== null && !interface_exists($definitionClass);
     }
 
     /**

--- a/tests/Feature/OptionalStatefulServicesProxificationTest.php
+++ b/tests/Feature/OptionalStatefulServicesProxificationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Feature;
+
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+
+final class OptionalStatefulServicesProxificationTest extends ServerTestCase
+{
+    public function testOptionalServiceIsProxifiedWhenItsDefinitionClassIsInstantiable(): void
+    {
+        $output = $this->runSluggerProxyCheck('coroutines');
+
+        self::assertStringContainsString('Slugger IS proxified.', $output);
+        self::assertStringContainsString('Slug: Hello-World', $output);
+    }
+
+    public function testOptionalServiceProxificationIsSkippedWhenItsDefinitionClassIsAnInterface(): void
+    {
+        $output = $this->runSluggerProxyCheck('coroutines_optional_services');
+
+        self::assertStringContainsString('Slugger IS NOT proxified.', $output);
+        self::assertStringContainsString('Slug: Hello-World', $output);
+    }
+
+    private function runSluggerProxyCheck(string $env): string
+    {
+        $process = $this->createConsoleProcess(['test:slugger:proxy-check'], ['APP_ENV' => $env]);
+        $process->setTimeout(self::coverageEnabled() ? 30 : 15);
+        $process->run();
+
+        $this->assertProcessSucceeded($process);
+
+        return $process->getOutput();
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Command/SluggerProxyCheckCommand.php
+++ b/tests/Fixtures/Symfony/TestBundle/Command/SluggerProxyCheckCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Command;
+
+use Override;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Container\Proxy\ContextualProxy;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+#[AsCommand(
+    name: 'test:slugger:proxy-check',
+    description: 'Tells whether the slugger service has been proxified and whether it is still usable.',
+)]
+final class SluggerProxyCheckCommand extends Command
+{
+    public function __construct(private readonly SluggerInterface $slugger)
+    {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $isProxified = $this->slugger instanceof ContextualProxy ? 'IS' : 'IS NOT';
+
+        $output->writeln(sprintf('Slugger %s proxified.', $isProxified));
+        $output->writeln(sprintf('Slug: %s', $this->slugger->slug('Hello World')));
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Service/InterfaceSluggerFactory.php
+++ b/tests/Fixtures/Symfony/TestBundle/Service/InterfaceSluggerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Service;
+
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+/**
+ * Allows to define the "slugger" service with an interface as its definition class.
+ */
+final class InterfaceSluggerFactory
+{
+    public static function newSlugger(): SluggerInterface
+    {
+        return new AsciiSlugger();
+    }
+}

--- a/tests/Fixtures/Symfony/app/config/coroutines_optional_services/framework.php
+++ b/tests/Fixtures/Symfony/app/config/coroutines_optional_services/framework.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('framework', [
+        'cache' => [
+            'app' => 'cache.adapter.array',
+            'system' => 'cache.adapter.array',
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/coroutines_optional_services/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/coroutines_optional_services/swoole.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Service\InterfaceSluggerFactory;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set('env(WORKER_COUNT)', 1);
+
+    $parameters->set('env(TASK_WORKER_COUNT)', 1);
+
+    $parameters->set('env(REACTOR_COUNT)', 1);
+
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'exception_handler' => [
+                'type' => 'symfony',
+            ],
+        ],
+        'task_worker' => [
+            'settings' => [
+                'worker_count' => '%env(int:TASK_WORKER_COUNT)%',
+            ],
+        ],
+        'platform' => [
+            'coroutines' => [
+                'enabled' => true,
+                'max_concurrency' => 30,
+                'max_service_instances' => 20,
+            ],
+        ],
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    // The "slugger" service is an optional service to proxify. Redefining it with an interface as its definition
+    // class must make the stateful services compiler pass skip its proxification instead of failing.
+    $services->set('slugger', SluggerInterface::class)
+        ->factory([InterfaceSluggerFactory::class, 'newSlugger']);
+};


### PR DESCRIPTION
Introduce OPTIONAL_SERVICES_TO_PROXIFY in StatefulServicesPass and move 'slugger' there. Applications are free to redefine such services in a way which cannot be proxified (e.g. with an interface as the definition class); in that case the proxification is now silently skipped instead of failing the container compilation.

Cover both branches with a feature test using a dedicated coroutines_optional_services environment which redefines the 'slugger' service through a factory returning SluggerInterface, and a console command reporting whether the injected slugger is a ContextualProxy.

Slugger has it's class defined only when `symfony/translations` are installed