### PR TITLE
feat(healthcheck): introduce separate process for server healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Symfony integration with [Open Swoole](https://openswoole.com/) and [Swoole](htt
   
 -   Access logs, (disabled by default) logs are configurable is a same way as apache mod log. Documentation of this feature is available [here](docs/swoole-access-logs.md).
 
+-   Liveness endpoint (disabled by default) on a port of its own, served by a dedicated process so that it keeps answering while every worker is busy. Projects can contribute their own checks to it. Documentation of this feature is available [here](docs/swoole-health.md).
+
 ## Requirements
 
 ### Current version

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -71,6 +71,22 @@ swoole:
     #     host: 0.0.0.0
     #     port: 9200
 
+    # enables the liveness endpoint on a separate port, served by a process of its own
+    # so that it keeps answering while every worker is busy
+    # by default it is disabled
+    healthcheck: true
+    # equals to:
+    # ---
+    # healthcheck:
+    #     enabled: true
+    #     host: 0.0.0.0
+    #     port: 9300
+    #     path: /healthz
+    #     # only relevant once the project registers a HealthCheck, see docs/swoole-health.md
+    #     checks:
+    #         interval: 5
+    #         staleness_threshold: 15
+
     # additional swoole symfony bundle services
     services:
 

--- a/docs/swoole-health.md
+++ b/docs/swoole-health.md
@@ -1,0 +1,129 @@
+# Liveness endpoint
+
+A Swoole server answers requests from a fixed pool of workers. Once every worker is busy,
+new connections queue, and a liveness probe pointed at the API port queues with them. An
+orchestrator reading that timeout as "the process is dead" restarts a container that was
+merely busy, which takes capacity away from a service that was already short of it.
+
+The liveness endpoint sidesteps the pool. It is served by a process added with
+`Swoole\Server::addProcess()`, not by a second listener: a listener would be dispatched to
+the same workers and would queue in exactly the same way.
+
+```yaml
+swoole:
+  http_server:
+    healthcheck: true
+    # equals to:
+    # healthcheck:
+    #     enabled: true
+    #     host: 0.0.0.0
+    #     port: 9300
+    #     path: /healthz
+```
+
+```console
+$ curl -i http://localhost:9300/healthz
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"ok":true}
+```
+
+The process is supervised by the server manager, the same as a worker: kill it and it comes
+back. Anything other than the configured path answers `404`.
+
+That answer is deliberately static. It reports one thing - this server has a process able to
+accept a connection and reply - and that is the question a liveness probe asks. Checking a
+database from a liveness probe turns a dependency blip into a restart of every replica at
+once, which is usually worse than the blip.
+
+## Adding checks
+
+When you do want the endpoint to reflect more than that, implement `HealthCheck`:
+
+```php
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheck;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheckResult;
+
+final readonly class DiskSpaceCheck implements HealthCheck
+{
+    public function name(): string
+    {
+        return 'disk_space';
+    }
+
+    public function check(): HealthCheckResult
+    {
+        $free = disk_free_space('/');
+
+        if ($free === false || $free < 100 * 1024 * 1024) {
+            return HealthCheckResult::unhealthy('less than 100MB free');
+        }
+
+        return HealthCheckResult::healthy();
+    }
+}
+```
+
+Implementations are autoconfigured, so registering the service is enough. Checks are
+reported alongside the static answer, and one of them failing takes the endpoint with it:
+
+```console
+$ curl -i http://localhost:9300/healthz
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+
+{"ok":false,"checks":{"disk_space":{"ok":false,"detail":"less than 100MB free"}}}
+```
+
+## How checks are run
+
+Checks are **not** evaluated while a probe is being served. A second process sweeps them on
+an interval and records each verdict in shared memory; the endpoint answers from that
+record and never waits for a check.
+
+```
+master ─┬─ manager ─┬─ worker(s)
+        │           ├─ health endpoint    accept loop, reads the recorded verdict
+        │           └─ health evaluator   sweeps the checks, writes the verdict
+```
+
+This is what keeps a check from doing to the endpoint what a saturated pool does to the API
+port. A check that hangs cannot delay a probe; it can only stop the verdict being refreshed.
+A verdict older than `staleness_threshold` is reported as unhealthy in its own right:
+
+```console
+$ curl -i http://localhost:9300/healthz
+HTTP/1.1 503 Service Unavailable
+
+{"ok":false,"stale":true,"checks":{"disk_space":{"ok":true,"detail":""}}}
+```
+
+```yaml
+swoole:
+  http_server:
+    healthcheck:
+      enabled: true
+      checks:
+        # seconds between two passes over every registered check
+        interval: 5
+        # seconds after which a verdict no longer counts as current
+        staleness_threshold: 15
+```
+
+A sweep counts as finished only once every check has been visited, so a sweep that dies half
+way through reads as stale rather than as partially fresh. The verdict is also stale between
+server start and the end of the first sweep - size the startup probe accordingly.
+
+The evaluating process only exists when at least one check is registered. With none, the
+endpoint costs a single process and answers exactly as it does above.
+
+## What a check may touch
+
+The evaluating process is forked from the server master, so it inherits the master's open
+file descriptors. A connection opened before the fork is shared with the master and every
+worker, and two processes reading the same socket corrupt each other's traffic.
+
+Checks are resolved from the container inside the forked process, on the first sweep, which
+keeps anything they construct out of the parent. Keep it that way: open what a check needs
+inside `check()` rather than in a constructor that could run earlier.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,10 @@ parameters:
         - src/Bridge/Swoole/Swoole.php
         # remove after upgrade to PHP 8.2
         - src/Server/HttpServer.php
+        # Same Swoole\Process reflection problem as HttpServer.php above
+        # (Internal error: Undefined constant "ITIMER_REAL")
+        - src/Server/Configurator/WithHealthProcess.php
+        - src/Server/Configurator/WithHealthEvaluatorProcess.php
     ignoreErrors:
         # Put false positives here
         - '#PHPDoc tag @var for variable \$row contains unresolvable type#'

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/HealthCheckPass.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/HealthCheckPass.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass;
+
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\ContainerConstants;
+use SwooleBundle\SwooleBundle\Server\Configurator\WithHealthEvaluatorProcess;
+use SwooleBundle\SwooleBundle\Server\Health\HealthReporter;
+use SwooleBundle\SwooleBundle\Server\Health\HealthStatusTable;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class HealthCheckPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(HealthReporter::class)) {
+            return;
+        }
+
+        $checkCount = count($container->findTaggedServiceIds(ContainerConstants::TAG_HEALTH_CHECK));
+        if ($checkCount === 0) {
+            $container->removeDefinition(WithHealthEvaluatorProcess::class);
+            $container->removeDefinition(HealthStatusTable::class);
+            $container->getDefinition(HealthReporter::class)->setArgument('$table', null);
+
+            return;
+        }
+
+        $container->getDefinition(HealthStatusTable::class)->setArgument('$checkCount', $checkCount);
+    }
+}

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ namespace SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection;
 use InvalidArgumentException;
 use RuntimeException;
 use SwooleBundle\SwooleBundle\Bridge\CommonSwoole\SystemSwooleFactory;
+use SwooleBundle\SwooleBundle\Server\Configurator\WithHealthProcess;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -108,6 +109,76 @@ final readonly class Configuration implements ConfigurationInterface
                                 ->scalarNode('port')
                                     ->cannotBeEmpty()
                                     ->defaultValue(9200)
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('healthcheck')
+                            ->info(
+                                'Liveness endpoint served by a dedicated process, '
+                                . 'unaffected by worker pool saturation.'
+                            )
+                            ->addDefaultsIfNotSet()
+                            ->beforeNormalization()
+                                ->ifTrue(
+                                    static fn($v): bool => is_string($v) || is_bool($v) || is_numeric($v) || $v === null
+                                )
+                                ->then(static fn($v): array => [
+                                    'enabled' => (bool) $v,
+                                    'host' => '0.0.0.0',
+                                    'port' => 9300,
+                                    'path' => WithHealthProcess::DEFAULT_PATH,
+                                ])
+                            ->end()
+                            ->children()
+                                ->booleanNode('enabled')
+                                    ->defaultFalse()
+                                ->end()
+                                ->scalarNode('host')
+                                    ->cannotBeEmpty()
+                                    ->defaultValue('0.0.0.0')
+                                ->end()
+                                ->scalarNode('port')
+                                    ->cannotBeEmpty()
+                                    ->defaultValue(9300)
+                                ->end()
+                                ->scalarNode('path')
+                                    ->cannotBeEmpty()
+                                    ->defaultValue(WithHealthProcess::DEFAULT_PATH)
+                                    ->validate()
+                                        ->ifTrue(static fn($v): bool => !str_starts_with((string) $v, '/'))
+                                        ->thenInvalid('Health path must start with a slash, got %s.')
+                                    ->end()
+                                ->end()
+                                ->arrayNode('checks')
+                                    ->info(
+                                        'Scheduling of the health checks registered by the project. '
+                                        . 'Ignored when none is registered.'
+                                    )
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->integerNode('interval')
+                                            ->info('Seconds between two passes over every registered check.')
+                                            ->min(1)
+                                            ->defaultValue(5)
+                                        ->end()
+                                        ->integerNode('staleness_threshold')
+                                            ->info(
+                                                'Seconds after which a verdict no longer counts as current '
+                                                . 'and the endpoint reports unhealthy.'
+                                            )
+                                            ->min(1)
+                                            ->defaultValue(15)
+                                        ->end()
+                                    ->end()
+                                    ->validate()
+                                        ->ifTrue(
+                                            static fn(array $v): bool => $v['staleness_threshold'] < $v['interval']
+                                        )
+                                        ->thenInvalid(
+                                            'A staleness_threshold below the interval leaves the health endpoint '
+                                            . 'permanently stale, got %s.'
+                                        )
+                                    ->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/ContainerConstants.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/ContainerConstants.php
@@ -29,5 +29,7 @@ interface ContainerConstants
 
     public const string TAG_STABILITY_CHECKER = 'swoole_bundle.stability_checker';
 
+    public const string TAG_HEALTH_CHECK = 'swoole_bundle.health_check';
+
     public const string PARAM_BLACKFIRE_MONITORING_ENABLED = 'swoole_bundle.blackfire_monitoring.enabled';
 }

--- a/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
+++ b/src/Bridge/Symfony/Bundle/DependencyInjection/SwooleExtension.php
@@ -39,6 +39,11 @@ use SwooleBundle\SwooleBundle\Common\Adapter\Swoole;
 use SwooleBundle\SwooleBundle\Server\Config\Socket;
 use SwooleBundle\SwooleBundle\Server\Config\Sockets;
 use SwooleBundle\SwooleBundle\Server\Configurator\Configurator;
+use SwooleBundle\SwooleBundle\Server\Configurator\WithHealthEvaluatorProcess;
+use SwooleBundle\SwooleBundle\Server\Configurator\WithHealthProcess;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheck;
+use SwooleBundle\SwooleBundle\Server\Health\HealthReporter;
+use SwooleBundle\SwooleBundle\Server\Health\HealthStatusTable;
 use SwooleBundle\SwooleBundle\Server\HttpServerConfiguration;
 use SwooleBundle\SwooleBundle\Server\Middleware\MiddlewareInjector;
 use SwooleBundle\SwooleBundle\Server\RequestHandler\AdvancedStaticFilesServer;
@@ -55,6 +60,7 @@ use SwooleBundle\SwooleBundle\Server\TaskHandler\TaskHandler;
 use SwooleBundle\SwooleBundle\Server\WorkerHandler\HMRWorkerStartHandler;
 use SwooleBundle\SwooleBundle\Server\WorkerHandler\WorkerStartHandler;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -134,6 +140,16 @@ use ZEngine\Core;
  *   enabled: 'off'|'auto'|'inotify'|'stat'|'external',
  *   file_path?: string,
  * }
+ * @phpstan-type HealthcheckConfig = array{
+ *   enabled: bool,
+ *   host: string,
+ *   port: int,
+ *   path: string,
+ *   checks: array{
+ *     interval: int,
+ *     staleness_threshold: int,
+ *   },
+ * }
  * @phpstan-type HttpServerConfig = array{
  *   running_mode: string,
  *   api: array{
@@ -141,6 +157,7 @@ use ZEngine\Core;
  *     host: string,
  *     port: int,
  *   },
+ *   healthcheck: HealthcheckConfig,
  *   hmr: HmrConfig,
  *   host: string,
  *   port: int,
@@ -185,6 +202,8 @@ final class SwooleExtension extends Extension
             ->addTag('swoole_bundle.bootable_service');
         $container->registerForAutoconfiguration(Configurator::class)
             ->addTag('swoole_bundle.server_configurator');
+        $container->registerForAutoconfiguration(HealthCheck::class)
+            ->addTag(ContainerConstants::TAG_HEALTH_CHECK);
 
         /** @var BundleConfig $config */
         $config = $this->processConfiguration($configuration, $configs);
@@ -361,6 +380,7 @@ final class SwooleExtension extends Extension
     {
         [
             'api' => $api,
+            'healthcheck' => $healthcheck,
             'hmr' => $hmr,
             'host' => $host,
             'port' => $port,
@@ -428,9 +448,39 @@ final class SwooleExtension extends Extension
             $sockets->addArgument(new Definition(Socket::class, [$api['host'], $api['port']]));
         }
 
+        if ($healthcheck['enabled']) {
+            $this->configureHttpServerHealthcheck($healthcheck, $container);
+        }
+
         $this->configureHttpServerHMR($hmr, $container);
 
         return $settings;
+    }
+
+    /**
+     * @param HealthcheckConfig $healthcheck
+     */
+    private function configureHttpServerHealthcheck(array $healthcheck, ContainerBuilder $container): void
+    {
+        $container->register(HealthStatusTable::class)
+            ->setFactory([HealthStatusTable::class, 'forChecks'])
+            ->setArgument('$checkCount', 0);
+
+        $container->register(HealthReporter::class)
+            ->setArgument('$table', new Reference(HealthStatusTable::class))
+            ->setArgument('$stalenessThreshold', $healthcheck['checks']['staleness_threshold']);
+
+        $container->register(WithHealthEvaluatorProcess::class)
+            ->setArgument('$table', new Reference(HealthStatusTable::class))
+            ->setArgument('$checks', new TaggedIteratorArgument(ContainerConstants::TAG_HEALTH_CHECK))
+            ->setArgument('$interval', $healthcheck['checks']['interval'])
+            ->addTag('swoole_bundle.server_configurator');
+
+        $container->register(WithHealthProcess::class)
+            ->setArgument('$socket', new Definition(Socket::class, [$healthcheck['host'], $healthcheck['port']]))
+            ->setArgument('$reporter', new Reference(HealthReporter::class))
+            ->setArgument('$path', $healthcheck['path'])
+            ->addTag('swoole_bundle.server_configurator');
     }
 
     /**

--- a/src/Bridge/Symfony/Bundle/SwooleBundle.php
+++ b/src/Bridge/Symfony/Bundle/SwooleBundle.php
@@ -11,6 +11,7 @@ use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\Compiler
     CacheWarmupFixerPass,
     ExceptionHandlerPass,
     FinalizeDefinitionsAfterRemovalPass,
+    HealthCheckPass,
     MessengerTransportFactoryPass,
     RouterOptimizerPass,
     SessionHandlerStorageConfiguratorPass,
@@ -34,6 +35,7 @@ final class SwooleBundle extends Bundle
         $container->addCompilerPass(new MessengerTransportFactoryPass());
         $container->addCompilerPass(new ExceptionHandlerPass());
         $container->addCompilerPass(new RouterOptimizerPass());
+        $container->addCompilerPass(new HealthCheckPass());
         $container->addCompilerPass(new StatefulServicesPass(), PassConfig::TYPE_BEFORE_REMOVING, -10000);
         $container->addCompilerPass(new FinalizeDefinitionsAfterRemovalPass(), PassConfig::TYPE_AFTER_REMOVING, -10000);
         $container->addCompilerPass(new SwooleTableStorageConfiguratorPass());

--- a/src/Server/Configurator/WithHealthEvaluatorProcess.php
+++ b/src/Server/Configurator/WithHealthEvaluatorProcess.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Configurator;
+
+use Swoole\Http\Server;
+use Swoole\Process;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheck;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheckResult;
+use SwooleBundle\SwooleBundle\Server\Health\HealthStatusTable;
+use Throwable;
+
+final readonly class WithHealthEvaluatorProcess implements Configurator
+{
+    /**
+     * @param iterable<HealthCheck> $checks
+     */
+    public function __construct(
+        private HealthStatusTable $table,
+        private iterable $checks,
+        private int $interval,
+    ) {}
+
+    public function configure(Server $server): void
+    {
+        $table = $this->table;
+        $checks = $this->checks;
+        $interval = $this->interval;
+
+        $server->addProcess(new Process(
+            static function () use ($table, $checks, $interval): void {
+                while (true) {
+                    try {
+                        foreach ($checks as $check) {
+                            try {
+                                $result = $check->check();
+                            } catch (Throwable $exception) {
+                                $result = HealthCheckResult::unhealthy($exception->getMessage());
+                            }
+
+                            $table->record($check->name(), $result);
+                        }
+
+                        $table->completeSweep(time());
+                    } catch (Throwable) {
+                    }
+
+                    sleep($interval);
+                }
+            },
+            false,
+            SOCK_DGRAM,
+            false,
+        ));
+    }
+}

--- a/src/Server/Configurator/WithHealthProcess.php
+++ b/src/Server/Configurator/WithHealthProcess.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Configurator;
+
+use RuntimeException;
+use Swoole\Http\Server;
+use Swoole\Process;
+use SwooleBundle\SwooleBundle\Server\Config\Socket;
+use SwooleBundle\SwooleBundle\Server\Health\HealthReport;
+use SwooleBundle\SwooleBundle\Server\Health\HealthReporter;
+
+final readonly class WithHealthProcess implements Configurator
+{
+    public const string DEFAULT_PATH = '/healthz';
+
+    private const int ACCEPT_TIMEOUT_SECONDS = 60;
+
+    private const int READ_TIMEOUT_SECONDS = 2;
+
+    private const int BIND_FAILURE_BACKOFF_SECONDS = 5;
+
+    private const int MAX_REQUEST_HEADERS = 100;
+
+    private const int MAX_LINE_BYTES = 8192;
+
+    private const array REASON_PHRASES = [
+        200 => '200 OK',
+        503 => '503 Service Unavailable',
+    ];
+
+    public function __construct(
+        private Socket $socket,
+        private HealthReporter $reporter,
+        private string $path = self::DEFAULT_PATH,
+    ) {}
+
+    public function configure(Server $server): void
+    {
+        $host = $this->socket->host();
+        $port = $this->socket->port();
+        $healthPath = $this->path;
+        $reporter = $this->reporter;
+
+        $server->addProcess(new Process(
+            static function () use ($host, $port, $healthPath, $reporter): void {
+                $listener = @stream_socket_server(sprintf('tcp://%s:%d', $host, $port), $errorNo, $errorMessage);
+
+                if ($listener === false) {
+                    sleep(self::BIND_FAILURE_BACKOFF_SECONDS);
+
+                    throw new RuntimeException(
+                        sprintf('Cannot bind health process to %s:%d: %s', $host, $port, $errorMessage),
+                        $errorNo,
+                    );
+                }
+
+                while (true) {
+                    $connection = @stream_socket_accept($listener, self::ACCEPT_TIMEOUT_SECONDS);
+
+                    if ($connection === false) {
+                        usleep(10_000);
+
+                        continue;
+                    }
+
+                    self::respond($connection, $healthPath, $reporter);
+                }
+            },
+            false,
+            SOCK_DGRAM,
+            false,
+        ));
+    }
+
+    /**
+     * @param resource $connection
+     */
+    private static function respond($connection, string $healthPath, HealthReporter $reporter): void
+    {
+        stream_set_timeout($connection, self::READ_TIMEOUT_SECONDS);
+
+        $requestLine = fgets($connection, self::MAX_LINE_BYTES);
+
+        if (!is_string($requestLine)) {
+            fclose($connection);
+
+            return;
+        }
+
+        for ($header = 0; $header < self::MAX_REQUEST_HEADERS; ++$header) {
+            $line = fgets($connection, self::MAX_LINE_BYTES);
+
+            if ($line === false || trim($line) === '') {
+                break;
+            }
+        }
+
+        $path = explode('?', explode(' ', $requestLine)[1] ?? '')[0];
+
+        if ($path === $healthPath) {
+            $report = $reporter->report(time());
+            $status = self::REASON_PHRASES[$report->statusCode];
+            $body = $report->json();
+        } else {
+            $status = '404 Not Found';
+            $body = (new HealthReport(404, ['ok' => false]))->json();
+        }
+
+        fwrite($connection, sprintf(
+            "HTTP/1.1 %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s",
+            $status,
+            strlen($body),
+            $body,
+        ));
+
+        fclose($connection);
+    }
+}

--- a/src/Server/Health/HealthCheck.php
+++ b/src/Server/Health/HealthCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Health;
+
+/**
+ * The evaluating process is forked from the server master. Anything a check touches must
+ * be created inside {@see self::check()} rather than inherited from the parent, or the
+ * resulting file descriptor is shared with the master and every worker.
+ */
+interface HealthCheck
+{
+    /**
+     * Stable identifier, used as the key under which this check is reported. Two checks
+     * answering the same name overwrite each other's verdict.
+     */
+    public function name(): string;
+
+    public function check(): HealthCheckResult;
+}

--- a/src/Server/Health/HealthCheckResult.php
+++ b/src/Server/Health/HealthCheckResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Health;
+
+final readonly class HealthCheckResult
+{
+    private function __construct(public bool $healthy, public string $detail) {}
+
+    public static function healthy(string $detail = ''): self
+    {
+        return new self(true, $detail);
+    }
+
+    public static function unhealthy(string $detail): self
+    {
+        return new self(false, $detail);
+    }
+}

--- a/src/Server/Health/HealthReport.php
+++ b/src/Server/Health/HealthReport.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Health;
+
+use JsonException;
+
+final readonly class HealthReport
+{
+    /**
+     * @param array<string, mixed> $body
+     */
+    public function __construct(public int $statusCode, public array $body) {}
+
+    /**
+     * @throws JsonException
+     */
+    public function json(): string
+    {
+        return json_encode($this->body, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+}

--- a/src/Server/Health/HealthReporter.php
+++ b/src/Server/Health/HealthReporter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Health;
+
+final readonly class HealthReporter
+{
+    public function __construct(
+        private ?HealthStatusTable $table,
+        private int $stalenessThreshold,
+    ) {}
+
+    public function report(int $now): HealthReport
+    {
+        if ($this->table === null) {
+            return new HealthReport(200, ['ok' => true]);
+        }
+
+        $lastSweepAt = $this->table->lastSweepAt();
+        $stale = $lastSweepAt === 0 || $now - $lastSweepAt > $this->stalenessThreshold;
+        $checks = $this->table->results();
+
+        $failing = false;
+
+        foreach ($checks as $check) {
+            if ($check['ok']) {
+                continue;
+            }
+
+            $failing = true;
+
+            break;
+        }
+
+        if ($stale) {
+            return new HealthReport(503, ['ok' => false, 'stale' => true, 'checks' => $checks]);
+        }
+
+        return new HealthReport($failing ? 503 : 200, ['ok' => !$failing, 'checks' => $checks]);
+    }
+}

--- a/src/Server/Health/HealthStatusTable.php
+++ b/src/Server/Health/HealthStatusTable.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Server\Health;
+
+use Assert\Assertion;
+use Swoole\Atomic\Long;
+use Swoole\Table;
+
+final readonly class HealthStatusTable
+{
+    private const int DETAIL_SIZE = 256;
+
+    private const int MINIMUM_ROWS = 64;
+
+    private function __construct(private Table $table, private Long $lastSweepAt) {}
+
+    public static function forChecks(int $checkCount): self
+    {
+        $table = new Table(max(self::MINIMUM_ROWS, $checkCount * 2));
+        $table->column('healthy', Table::TYPE_INT, 1);
+        $table->column('detail', Table::TYPE_STRING, self::DETAIL_SIZE);
+        $table->create();
+
+        return new self($table, new Long(0));
+    }
+
+    public function record(string $name, HealthCheckResult $result): void
+    {
+        $this->table->set($name, [
+            'healthy' => (int) $result->healthy,
+            'detail' => mb_substr($result->detail, 0, self::DETAIL_SIZE - 1),
+        ]);
+    }
+
+    public function completeSweep(int $timestamp): void
+    {
+        $this->lastSweepAt->set($timestamp);
+    }
+
+    public function lastSweepAt(): int
+    {
+        return $this->lastSweepAt->get();
+    }
+
+    /**
+     * @return array<string, array{ok: bool, detail: string}>
+     */
+    public function results(): array
+    {
+        $results = [];
+
+        /** @var array{healthy: int, detail: string} $row */
+        foreach ($this->table as $name => $row) {
+            Assertion::string($name);
+
+            $results[$name] = [
+                'ok' => (bool) $row['healthy'],
+                'detail' => $row['detail'],
+            ];
+        }
+
+        ksort($results);
+
+        return $results;
+    }
+}

--- a/tests/Feature/SwooleServerHealthCheckFailureTest.php
+++ b/tests/Feature/SwooleServerHealthCheckFailureTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Feature;
+
+use Override;
+use Swoole\Coroutine;
+use SwooleBundle\SwooleBundle\Client\HttpClient;
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+
+final class SwooleServerHealthCheckFailureTest extends ServerTestCase
+{
+    private const int APP_PORT = 9999;
+    private const int HEALTH_PORT = 9997;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deleteVarDirectory();
+        $this->killAllProcessesListeningOnPort(self::HEALTH_PORT);
+    }
+
+    public function testACheckThatCannotBeBuiltDoesNotRestartTheEvaluatorInALoop(): void
+    {
+        $envs = ['APP_ENV' => self::resolveEnvironment('health_checks_unconstructable')];
+        $this->startServer($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $client = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+            $this->assertTrue($client->connect(3, 1, true));
+
+            $before = $this->serverProcessIds();
+            $this->assertNotEmpty($before, 'Could not find any server process.');
+
+            Coroutine::sleep(5);
+
+            $this->assertSame(
+                $before,
+                $this->serverProcessIds(),
+                'A server process is being restarted in a loop.',
+            );
+
+            $response = $client->send('/healthz')['response'];
+
+            $this->assertSame(503, $response['statusCode']);
+            $this->assertTrue($response['body']['stale']);
+        });
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function serverProcessIds(): array
+    {
+        $masterPid = (int) trim((string) file_get_contents($this->getVarDirectoryPath() . '/swoole.pid'));
+
+        $childrenOf = [];
+
+        foreach (explode("\n", trim((string) shell_exec('ps -o pid,ppid'))) as $line) {
+            if (preg_match('/^\s*(\d+)\s+(\d+)/', $line, $matches) !== 1) {
+                continue;
+            }
+
+            $childrenOf[(int) $matches[2]][] = (int) $matches[1];
+        }
+
+        $descendants = [];
+        $queue = [$masterPid];
+
+        while ($queue !== []) {
+            foreach ($childrenOf[array_shift($queue)] ?? [] as $child) {
+                $descendants[] = $child;
+                $queue[] = $child;
+            }
+        }
+
+        sort($descendants);
+
+        return $descendants;
+    }
+
+    /**
+     * @param array<string, string> $envs
+     */
+    private function startServer(array $envs): void
+    {
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            sprintf('--port=%d', self::APP_PORT),
+        ], $envs);
+
+        $serverStart->setTimeout(5);
+        $serverStart->disableOutput();
+        $serverStart->run();
+
+        $this->assertProcessSucceeded($serverStart);
+    }
+}

--- a/tests/Feature/SwooleServerHealthChecksTest.php
+++ b/tests/Feature/SwooleServerHealthChecksTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Feature;
+
+use Override;
+use Swoole\Coroutine;
+use SwooleBundle\SwooleBundle\Client\HttpClient;
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+
+final class SwooleServerHealthChecksTest extends ServerTestCase
+{
+    private const int APP_PORT = 9999;
+    private const int HEALTH_PORT = 9997;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deleteVarDirectory();
+        $this->killAllProcessesListeningOnPort(self::HEALTH_PORT);
+        $this->clearUnhealthyFlag();
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->clearUnhealthyFlag();
+
+        parent::tearDown();
+    }
+
+    public function testRegisteredHealthChecksAreReportedAndCanFailTheEndpoint(): void
+    {
+        $envs = ['APP_ENV' => self::resolveEnvironment('health_checks')];
+        $this->startServer($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $client = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+            $this->assertTrue($client->connect(3, 1, true));
+
+            $healthy = $this->probeUntil($client, static fn(array $body): bool => $body['ok'] === true);
+
+            $this->assertSame(200, $healthy['statusCode']);
+            $this->assertSame(
+                ['ok' => true, 'checks' => ['flagged' => ['ok' => true, 'detail' => '']]],
+                $healthy['body'],
+            );
+
+            file_put_contents($this->unhealthyFlagPath(), 'flipped by test');
+
+            $unhealthy = $this->probeUntil($client, static fn(array $body): bool => $body['ok'] === false);
+
+            $this->assertSame(503, $unhealthy['statusCode']);
+            $this->assertSame(
+                ['ok' => false, 'checks' => ['flagged' => ['ok' => false, 'detail' => 'flipped by test']]],
+                $unhealthy['body'],
+            );
+        });
+    }
+
+    public function testABlockingHealthCheckCannotWedgeTheEndpoint(): void
+    {
+        $envs = ['APP_ENV' => self::resolveEnvironment('health_checks_blocking')];
+        $this->startServer($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $client = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+            $this->assertTrue($client->connect(3, 1, true));
+
+            $startedAt = microtime(true);
+            $response = $client->send('/healthz')['response'];
+            $elapsed = microtime(true) - $startedAt;
+
+            $this->assertLessThan(
+                1.0,
+                $elapsed,
+                'A blocking check must not delay the endpoint.',
+            );
+            $this->assertSame(503, $response['statusCode']);
+            $this->assertTrue($response['body']['stale']);
+
+            Coroutine::sleep(5);
+
+            $startedAt = microtime(true);
+            $response = $client->send('/healthz')['response'];
+            $elapsed = microtime(true) - $startedAt;
+
+            $this->assertLessThan(1.0, $elapsed);
+            $this->assertSame(503, $response['statusCode']);
+            $this->assertTrue($response['body']['stale']);
+        });
+    }
+
+    /**
+     * @param callable(array<string, mixed>): bool $isSettled
+     * @return array{statusCode: int, body: array<string, mixed>}
+     */
+    private function probeUntil(HttpClient $client, callable $isSettled, int $attempts = 10): array
+    {
+        $response = null;
+
+        for ($attempt = 0; $attempt < $attempts; ++$attempt) {
+            $response = $client->send('/healthz')['response'];
+
+            if ($isSettled($response['body'])) {
+                break;
+            }
+
+            Coroutine::sleep(1);
+        }
+
+        $this->assertNotNull($response, 'The health endpoint never answered.');
+
+        return $response;
+    }
+
+    private function unhealthyFlagPath(): string
+    {
+        return $this->getVarDirectoryPath() . '/health-check-unhealthy';
+    }
+
+    private function clearUnhealthyFlag(): void
+    {
+        if (!file_exists($this->unhealthyFlagPath())) {
+            return;
+        }
+
+        unlink($this->unhealthyFlagPath());
+    }
+
+    /**
+     * @param array<string, string> $envs
+     */
+    private function startServer(array $envs): void
+    {
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            sprintf('--port=%d', self::APP_PORT),
+        ], $envs);
+
+        $serverStart->setTimeout(5);
+        $serverStart->disableOutput();
+        $serverStart->run();
+
+        $this->assertProcessSucceeded($serverStart);
+    }
+}

--- a/tests/Feature/SwooleServerHealthProcessTest.php
+++ b/tests/Feature/SwooleServerHealthProcessTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Feature;
+
+use ArrayObject;
+use Override;
+use Swoole\Coroutine;
+use SwooleBundle\SwooleBundle\Client\HttpClient;
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Test\ServerTestCase;
+
+final class SwooleServerHealthProcessTest extends ServerTestCase
+{
+    private const int APP_PORT = 9999;
+    private const int HEALTH_PORT = 9997;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deleteVarDirectory();
+        $this->killAllProcessesListeningOnPort(self::HEALTH_PORT);
+    }
+
+    public function testHealthEndpointRespondsWhileEveryWorkerIsBlocked(): void
+    {
+        $envs = ['APP_ENV' => self::resolveEnvironment('health')];
+        $this->startServer($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $appClient = HttpClient::fromDomain('localhost', self::APP_PORT, false);
+            $this->assertTrue($appClient->connect(3, 1, true));
+
+            $blocking = new ArrayObject(['finished' => false]);
+            $waitGroup = $this->getSwoole()->waitGroup();
+
+            go(function () use ($waitGroup, $blocking): void {
+                $waitGroup->add();
+                $client = HttpClient::fromDomain('localhost', self::APP_PORT, false, ['timeout' => 15]);
+                $response = $client->send('/test/blocking/5000', timeout: 15)['response'];
+
+                $this->assertSame(200, $response['statusCode']);
+                $blocking['finished'] = true;
+                $waitGroup->done();
+            });
+
+            Coroutine::sleep(1);
+
+            $healthClient = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+
+            $startedAt = microtime(true);
+            $response = $healthClient->send('/healthz')['response'];
+            $elapsed = microtime(true) - $startedAt;
+
+            $this->assertFalse(
+                $blocking['finished'],
+                'The blocking request must still be occupying the worker while the health endpoint is probed.',
+            );
+            $this->assertSame(200, $response['statusCode']);
+            $this->assertSame(['ok' => true], $response['body']);
+            $this->assertLessThan(
+                1.0,
+                $elapsed,
+                'Health endpoint must answer without queueing behind the blocked worker pool.',
+            );
+
+            $waitGroup->wait();
+            $this->assertTrue($blocking['finished']);
+        });
+    }
+
+    public function testHealthEndpointSurvivesAClientThatSendsNothing(): void
+    {
+        $envs = ['APP_ENV' => self::resolveEnvironment('health')];
+        $this->startServer($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $healthClient = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+            $this->assertTrue($healthClient->connect(3, 1, true));
+            $this->assertSame(200, $healthClient->send('/healthz')['response']['statusCode']);
+
+            $silent = stream_socket_client(sprintf('tcp://localhost:%d', self::HEALTH_PORT));
+            $this->assertNotFalse($silent, 'Could not open the silent connection.');
+
+            $probe = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+            $response = $probe->send('/healthz', timeout: 5)['response'];
+
+            $this->assertSame(200, $response['statusCode']);
+            $this->assertSame(['ok' => true], $response['body']);
+
+            fclose($silent);
+        });
+    }
+
+    public function testHealthEndpointIsServedOnTheConfiguredPath(): void
+    {
+        $envs = ['APP_ENV' => self::resolveEnvironment('health_custom_path')];
+        $this->startServer($envs);
+
+        $this->runAsCoroutineAndWait(function () use ($envs): void {
+            $this->deferServerStop([], $envs);
+
+            $healthClient = HttpClient::fromDomain('localhost', self::HEALTH_PORT, false);
+            // The health process binds its socket after the start command has returned.
+            $this->assertTrue($healthClient->connect(3, 1, true));
+
+            $configured = $healthClient->send('/alive')['response'];
+            $this->assertSame(200, $configured['statusCode']);
+            $this->assertSame(['ok' => true], $configured['body']);
+
+            $default = $healthClient->send('/healthz')['response'];
+            $this->assertSame(404, $default['statusCode']);
+        });
+    }
+
+    /**
+     * @param array<string, string> $envs
+     */
+    private function startServer(array $envs): void
+    {
+        $serverStart = $this->createConsoleProcess([
+            'swoole:server:start',
+            '--host=localhost',
+            sprintf('--port=%d', self::APP_PORT),
+        ], $envs);
+
+        $serverStart->setTimeout(5);
+        $serverStart->disableOutput();
+        $serverStart->run();
+
+        $this->assertProcessSucceeded($serverStart);
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/Controller/BlockingController.php
+++ b/tests/Fixtures/Symfony/TestBundle/Controller/BlockingController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class BlockingController
+{
+    #[Route(path: '/test/blocking/{milliseconds}', methods: ['GET'], requirements: ['milliseconds' => '\d+'])]
+    public function block(int $milliseconds): JsonResponse
+    {
+        usleep($milliseconds * 1000);
+
+        return new JsonResponse(['blocked' => $milliseconds], 200);
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/HealthCheck/BlockingHealthCheck.php
+++ b/tests/Fixtures/Symfony/TestBundle/HealthCheck/BlockingHealthCheck.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck;
+
+use Override;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheck;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheckResult;
+
+final readonly class BlockingHealthCheck implements HealthCheck
+{
+    public function __construct(private int $seconds) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'blocking';
+    }
+
+    #[Override]
+    public function check(): HealthCheckResult
+    {
+        sleep($this->seconds);
+
+        return HealthCheckResult::healthy();
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/HealthCheck/FlaggedHealthCheck.php
+++ b/tests/Fixtures/Symfony/TestBundle/HealthCheck/FlaggedHealthCheck.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck;
+
+use Override;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheck;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheckResult;
+
+final readonly class FlaggedHealthCheck implements HealthCheck
+{
+    public function __construct(private string $flagFile) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'flagged';
+    }
+
+    #[Override]
+    public function check(): HealthCheckResult
+    {
+        if (!file_exists($this->flagFile)) {
+            return HealthCheckResult::healthy();
+        }
+
+        return HealthCheckResult::unhealthy(trim((string) file_get_contents($this->flagFile)));
+    }
+}

--- a/tests/Fixtures/Symfony/TestBundle/HealthCheck/UnconstructableHealthCheck.php
+++ b/tests/Fixtures/Symfony/TestBundle/HealthCheck/UnconstructableHealthCheck.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck;
+
+use Override;
+use RuntimeException;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheck;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheckResult;
+
+final readonly class UnconstructableHealthCheck implements HealthCheck
+{
+    public function __construct()
+    {
+        throw new RuntimeException('this check cannot be built');
+    }
+
+    #[Override]
+    public function name(): string
+    {
+        return 'unconstructable';
+    }
+
+    #[Override]
+    public function check(): HealthCheckResult
+    {
+        return HealthCheckResult::healthy();
+    }
+}

--- a/tests/Fixtures/Symfony/app/config/health/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/health/swoole.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'healthcheck' => [
+                'enabled' => true,
+                'port' => 9997,
+            ],
+            'settings' => [
+                'worker_count' => 1,
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/health_checks/services.php
+++ b/tests/Fixtures/Symfony/app/config/health_checks/services.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck\FlaggedHealthCheck;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->services()
+        ->set(FlaggedHealthCheck::class)
+        ->arg('$flagFile', '%kernel.project_dir%/var/health-check-unhealthy')
+        ->autoconfigure();
+};

--- a/tests/Fixtures/Symfony/app/config/health_checks/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/health_checks/swoole.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'healthcheck' => [
+                'enabled' => true,
+                'port' => 9997,
+                'checks' => [
+                    'interval' => 1,
+                    'staleness_threshold' => 3,
+                ],
+            ],
+            'settings' => [
+                'worker_count' => 1,
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/health_checks_blocking/services.php
+++ b/tests/Fixtures/Symfony/app/config/health_checks_blocking/services.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck\BlockingHealthCheck;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->services()
+        ->set(BlockingHealthCheck::class)
+        ->arg('$seconds', 300)
+        ->autoconfigure();
+};

--- a/tests/Fixtures/Symfony/app/config/health_checks_blocking/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/health_checks_blocking/swoole.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'healthcheck' => [
+                'enabled' => true,
+                'port' => 9997,
+                'checks' => [
+                    'interval' => 1,
+                    'staleness_threshold' => 3,
+                ],
+            ],
+            'settings' => [
+                'worker_count' => 1,
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/health_checks_unconstructable/services.php
+++ b/tests/Fixtures/Symfony/app/config/health_checks_unconstructable/services.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck\UnconstructableHealthCheck;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->services()
+        ->set(UnconstructableHealthCheck::class)
+        ->autoconfigure();
+};

--- a/tests/Fixtures/Symfony/app/config/health_checks_unconstructable/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/health_checks_unconstructable/swoole.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'healthcheck' => [
+                'enabled' => true,
+                'port' => 9997,
+                'checks' => [
+                    'interval' => 1,
+                    'staleness_threshold' => 3,
+                ],
+            ],
+            'settings' => [
+                'worker_count' => 1,
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/health_custom_path/swoole.php
+++ b/tests/Fixtures/Symfony/app/config/health_custom_path/swoole.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('swoole', [
+        'http_server' => [
+            'healthcheck' => [
+                'enabled' => true,
+                'port' => 9997,
+                'path' => '/alive',
+            ],
+            'settings' => [
+                'worker_count' => 1,
+            ],
+        ],
+    ]);
+};

--- a/tests/Fixtures/Symfony/app/config/services.php
+++ b/tests/Fixtures/Symfony/app/config/services.php
@@ -33,6 +33,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             // depends on fixture services (security.event_dispatcher.main/api) only registered in the
             // coroutines_security* environments, so it must not be auto-registered everywhere else.
             __DIR__ . '/../../TestBundle/Command/SecurityFirewallEventDispatcherProxyCheckCommand.php',
+            __DIR__ . '/../../TestBundle/HealthCheck',
         ]);
 
     $services->load(

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/HealthCheckPassTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/CompilerPass/HealthCheckPassTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\CompilerPass\HealthCheckPass;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\ContainerConstants;
+use SwooleBundle\SwooleBundle\Server\Configurator\WithHealthEvaluatorProcess;
+use SwooleBundle\SwooleBundle\Server\Health\HealthReporter;
+use SwooleBundle\SwooleBundle\Server\Health\HealthStatusTable;
+use SwooleBundle\SwooleBundle\Tests\Fixtures\Symfony\TestBundle\HealthCheck\FlaggedHealthCheck;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+#[CoversClass(HealthCheckPass::class)]
+final class HealthCheckPassTest extends TestCase
+{
+    public function testWithoutRegisteredChecksNothingIsLeftToEvaluate(): void
+    {
+        $container = $this->containerWithHealthEnabled();
+
+        (new HealthCheckPass())->process($container);
+
+        self::assertFalse($container->hasDefinition(WithHealthEvaluatorProcess::class));
+        self::assertFalse($container->hasDefinition(HealthStatusTable::class));
+        self::assertNull($container->getDefinition(HealthReporter::class)->getArgument('$table'));
+    }
+
+    public function testTheStatusTableIsSizedToTheRegisteredChecks(): void
+    {
+        $container = $this->containerWithHealthEnabled();
+        $container->register('check.one', FlaggedHealthCheck::class)
+            ->addTag(ContainerConstants::TAG_HEALTH_CHECK);
+        $container->register('check.two', FlaggedHealthCheck::class)
+            ->addTag(ContainerConstants::TAG_HEALTH_CHECK);
+
+        (new HealthCheckPass())->process($container);
+
+        self::assertTrue($container->hasDefinition(WithHealthEvaluatorProcess::class));
+        self::assertSame(2, $container->getDefinition(HealthStatusTable::class)->getArgument('$checkCount'));
+    }
+
+    public function testAContainerWithoutTheHealthEndpointIsLeftAlone(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('check.one', FlaggedHealthCheck::class)
+            ->addTag(ContainerConstants::TAG_HEALTH_CHECK);
+
+        (new HealthCheckPass())->process($container);
+
+        self::assertContains('check.one', array_keys($container->getDefinitions()));
+        self::assertFalse($container->hasDefinition(HealthStatusTable::class));
+    }
+
+    private function containerWithHealthEnabled(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(HealthStatusTable::class)
+            ->setFactory([HealthStatusTable::class, 'forChecks'])
+            ->setArgument('$checkCount', 0);
+
+        $container->register(HealthReporter::class)
+            ->setArgument('$table', new Reference(HealthStatusTable::class))
+            ->setArgument('$stalenessThreshold', 15);
+
+        $container->register(WithHealthEvaluatorProcess::class);
+
+        return $container;
+    }
+}

--- a/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/HealthConfigurationTest.php
+++ b/tests/Unit/Bridge/Symfony/Bundle/DependencyInjection/HealthConfigurationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Unit\Bridge\Symfony\Bundle\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SwooleBundle\SwooleBundle\Bridge\Symfony\Bundle\DependencyInjection\Configuration;
+use SwooleBundle\SwooleBundle\Server\Configurator\WithHealthProcess;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+#[CoversClass(Configuration::class)]
+final class HealthConfigurationTest extends TestCase
+{
+    public function testHealthPathDefaultsToHealthz(): void
+    {
+        $config = $this->process(['healthcheck' => ['enabled' => true]]);
+
+        self::assertSame(WithHealthProcess::DEFAULT_PATH, $config['http_server']['healthcheck']['path']);
+    }
+
+    public function testHealthPathIsConfigurable(): void
+    {
+        $config = $this->process(['healthcheck' => ['enabled' => true, 'path' => '/alive']]);
+
+        self::assertSame('/alive', $config['http_server']['healthcheck']['path']);
+    }
+
+    public function testHealthPathWithoutLeadingSlashIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('must start with a slash');
+
+        $this->process(['healthcheck' => ['enabled' => true, 'path' => 'alive']]);
+    }
+
+    public function testCheckSchedulingHasDefaults(): void
+    {
+        $config = $this->process(['healthcheck' => ['enabled' => true]]);
+
+        self::assertSame(
+            ['interval' => 5, 'staleness_threshold' => 15],
+            $config['http_server']['healthcheck']['checks'],
+        );
+    }
+
+    public function testCheckSchedulingIsConfigurable(): void
+    {
+        $config = $this->process([
+            'healthcheck' => ['enabled' => true, 'checks' => ['interval' => 1, 'staleness_threshold' => 3]],
+        ]);
+
+        self::assertSame(
+            ['interval' => 1, 'staleness_threshold' => 3],
+            $config['http_server']['healthcheck']['checks'],
+        );
+    }
+
+    /**
+     * A threshold below the interval leaves the endpoint permanently stale.
+     */
+    public function testStalenessThresholdBelowTheIntervalIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('staleness_threshold');
+
+        $this->process([
+            'healthcheck' => ['enabled' => true, 'checks' => ['interval' => 10, 'staleness_threshold' => 5]],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $httpServer
+     * @return array<string, mixed>
+     */
+    private function process(array $httpServer): array
+    {
+        return (new Processor())->processConfiguration(
+            Configuration::fromTreeBuilder(),
+            [['http_server' => $httpServer]],
+        );
+    }
+}

--- a/tests/Unit/Server/Health/HealthReporterTest.php
+++ b/tests/Unit/Server/Health/HealthReporterTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwooleBundle\SwooleBundle\Tests\Unit\Server\Health;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use SwooleBundle\SwooleBundle\Server\Health\HealthCheckResult;
+use SwooleBundle\SwooleBundle\Server\Health\HealthReporter;
+use SwooleBundle\SwooleBundle\Server\Health\HealthStatusTable;
+
+#[CoversClass(HealthReporter::class)]
+final class HealthReporterTest extends TestCase
+{
+    private const int NOW = 1_000;
+    private const int STALENESS_THRESHOLD = 3;
+
+    public function testWithoutRegisteredChecksTheStaticAnswerIsServed(): void
+    {
+        $report = (new HealthReporter(null, self::STALENESS_THRESHOLD))->report(self::NOW);
+
+        self::assertSame(200, $report->statusCode);
+        self::assertSame(['ok' => true], $report->body);
+    }
+
+    public function testHealthyChecksAreReportedAlongsideTheStaticAnswer(): void
+    {
+        $table = HealthStatusTable::forChecks(1);
+        $table->record('database', HealthCheckResult::healthy());
+        $table->completeSweep(self::NOW);
+
+        $report = (new HealthReporter($table, self::STALENESS_THRESHOLD))->report(self::NOW);
+
+        self::assertSame(200, $report->statusCode);
+        self::assertSame(
+            ['ok' => true, 'checks' => ['database' => ['ok' => true, 'detail' => '']]],
+            $report->body,
+        );
+    }
+
+    public function testAnUnhealthyCheckFailsTheReport(): void
+    {
+        $table = HealthStatusTable::forChecks(2);
+        $table->record('database', HealthCheckResult::unhealthy('connection refused'));
+        $table->record('queue', HealthCheckResult::healthy());
+        $table->completeSweep(self::NOW);
+
+        $report = (new HealthReporter($table, self::STALENESS_THRESHOLD))->report(self::NOW);
+
+        self::assertSame(503, $report->statusCode);
+        self::assertSame(
+            [
+                'ok' => false,
+                'checks' => [
+                    'database' => ['ok' => false, 'detail' => 'connection refused'],
+                    'queue' => ['ok' => true, 'detail' => ''],
+                ],
+            ],
+            $report->body,
+        );
+    }
+
+    public function testASweepOlderThanTheThresholdIsStale(): void
+    {
+        $table = HealthStatusTable::forChecks(1);
+        $table->record('database', HealthCheckResult::healthy());
+        $table->completeSweep(self::NOW - self::STALENESS_THRESHOLD - 1);
+
+        $report = (new HealthReporter($table, self::STALENESS_THRESHOLD))->report(self::NOW);
+
+        self::assertSame(503, $report->statusCode);
+        self::assertSame(
+            [
+                'ok' => false,
+                'stale' => true,
+                'checks' => ['database' => ['ok' => true, 'detail' => '']],
+            ],
+            $report->body,
+        );
+    }
+
+    public function testASweepThatNeverCompletedIsStale(): void
+    {
+        $report = (new HealthReporter(HealthStatusTable::forChecks(1), self::STALENESS_THRESHOLD))
+            ->report(self::NOW);
+
+        self::assertSame(503, $report->statusCode);
+        self::assertSame(['ok' => false, 'stale' => true, 'checks' => []], $report->body);
+    }
+
+    public function testADetailThatIsNotValidUtf8IsStillEncodable(): void
+    {
+        $table = HealthStatusTable::forChecks(1);
+        $table->record('database', HealthCheckResult::unhealthy("handshake failed: \xB1\x31\xFF"));
+        $table->completeSweep(self::NOW);
+
+        $report = (new HealthReporter($table, self::STALENESS_THRESHOLD))->report(self::NOW);
+
+        self::assertJson($report->json());
+        self::assertStringContainsString('handshake failed', $report->json());
+    }
+
+    public function testASweepExactlyOnTheThresholdIsStillFresh(): void
+    {
+        $table = HealthStatusTable::forChecks(1);
+        $table->record('database', HealthCheckResult::healthy());
+        $table->completeSweep(self::NOW - self::STALENESS_THRESHOLD);
+
+        $report = (new HealthReporter($table, self::STALENESS_THRESHOLD))->report(self::NOW);
+
+        self::assertSame(200, $report->statusCode);
+    }
+}


### PR DESCRIPTION
## Dedicated health check process

Adds a liveness endpoint served by a dedicated process (`Swoole\Server::addProcess()`)
rather than a second listener, so probes never queue behind a saturated worker pool.

```yaml
swoole:
  http_server:
    healthcheck: true   # host: 0.0.0.0, port: 9300, path: /healthz

GET /healthz returns a static {"ok":true}. The process is manager-supervised, so it
restarts like a worker; any other path returns 404.

Custom checks

Services implementing Server\Health\HealthCheck are autoconfigured and reported
alongside the static answer; any failure turns the endpoint into a 503.

Checks are not evaluated while a probe is served. A second process sweeps them on an
interval and records verdicts in a Swoole table; the endpoint reads that record and never
blocks. A verdict older than staleness_threshold is itself reported unhealthy. The
evaluator process only exists when at least one check is registered.

swoole:
  http_server:
    healthcheck:
      enabled: true
      checks:
        interval: 5
        staleness_threshold: 15

Checks are resolved from the container inside the forked process on the first sweep, so
nothing they construct leaks into the master's file descriptors.

Contents

- Server\Health\* — HealthCheck, HealthCheckResult, HealthReport, HealthReporter,
HealthStatusTable
- Server\Configurator\WithHealthProcess / WithHealthEvaluatorProcess
- HealthCheckPass + swoole.http_server.healthcheck configuration
- Unit tests for the reporter, compiler pass, and configuration; feature tests for the
endpoint, registered checks, blocking checks, and check failures
- docs/swoole-health.md

Two notes on the CI checks I ran earlier, in case they're useful for the PR:
- Everything passes except `SymfonyProfilerTest::testProfilerIsEnabled('coroutines_profiler')`, which fails identically on `origin/develop` and is untouched by this branch — worth mentioning in the PR only if CI flags it.
- I couldn't run commitlint locally (npm registry unreachable), but the three commit subjects are conventional-format and should pass.